### PR TITLE
Enable compatiblity with krb5 1.8

### DIFF
--- a/PyKAdminErrors.c
+++ b/PyKAdminErrors.c
@@ -89,8 +89,12 @@ void PyKAdminError_init(PyObject *module) {
     PyKAdminError_insert(module, KADM5_SETKEY3_ETYPE_MISMATCH,   "SetKey3EnctypeMismatchError",  "Mismatched enctypes for setkey3");
     PyKAdminError_insert(module, KADM5_MISSING_KRB5_CONF_PARAMS, "MissingKrb5ConfParamsError",   "Missing parameters in krb5.conf required for kadmin client");
     PyKAdminError_insert(module, KADM5_XDR_FAILURE,              "XDRFailureError",              "XDR encoding error");
+#ifdef KADM5_CANT_RESOLVE
     PyKAdminError_insert(module, KADM5_CANT_RESOLVE,             "CantResolveError",             "");
+#endif
+#ifdef KADM5_PASS_Q_GENERIC
     PyKAdminError_insert(module, KADM5_PASS_Q_GENERIC,           "PasswordGenericError",         "Database synchronization failed");
+#endif
 
 }
 


### PR DESCRIPTION
KADM5_CANT_RESOLVE and KADM5_PASS_Q_GENERIC were added in krb5 1.9 and block compilation as "undeclared (first use in this function)" with 1.8.
