### PR TITLE
create_principal extension + don't leak memory when raising errors

### DIFF
--- a/PyKAdminErrors.h
+++ b/PyKAdminErrors.h
@@ -12,7 +12,7 @@
 
 #include "pykadmin.h"
 
-#define PyKAdmin_RETURN_ERROR(value, caller) { PyKAdminError_raise_error((long)value, caller); return NULL; }
+#define PyKAdmin_RETURN_ERROR(value, caller) { PyKAdminError_raise_error((long)value, caller); has_error=1; goto epilog; }
 
 //#define PyKAdmin_RETURN_KADM5_ERROR(retval, caller) { PyKAdminError_raise_kadm_error(retval, caller); return NULL; }
 //#define PyKAdmin_RETURN_KRB5_ERROR(code, caller) { PyKAdminError_raise_krb5_error(code, caller); return NULL; }

--- a/PyKAdminIterator.c
+++ b/PyKAdminIterator.c
@@ -82,6 +82,7 @@ PyKAdminIterator *PyKAdminIterator_principal_iterator(PyKAdminObject *kadmin, ch
 
     kadm5_ret_t retval = KADM5_OK;
     PyKAdminIterator *iter = PyObject_New(PyKAdminIterator, &PyKAdminIterator_Type);
+    int has_error = 0;
 
     if (iter) {
 
@@ -94,7 +95,8 @@ PyKAdminIterator *PyKAdminIterator_principal_iterator(PyKAdminObject *kadmin, ch
             retval = kadm5_get_principals(kadmin->server_handle, match, &iter->names, &iter->count);
             if (retval != KADM5_OK) { PyKAdmin_RETURN_ERROR(retval, "kadm5_get_principals"); }
     }
-
+ epilog:
+    if (has_error) return NULL;
     Py_XINCREF(iter);
     return iter;
 }
@@ -104,6 +106,7 @@ PyKAdminIterator *PyKAdminIterator_policy_iterator(PyKAdminObject *kadmin, char 
 
     kadm5_ret_t retval = KADM5_OK;
     PyKAdminIterator *iter = PyObject_New(PyKAdminIterator, &PyKAdminIterator_Type);
+    int has_error = 0;
 
     if (iter) {
 
@@ -116,7 +119,8 @@ PyKAdminIterator *PyKAdminIterator_policy_iterator(PyKAdminObject *kadmin, char 
             retval = kadm5_get_policies(kadmin->server_handle, match, &iter->names, &iter->count);
             if (retval != KADM5_OK) { PyKAdmin_RETURN_ERROR(retval, "kadm5_get_policies"); }
     }
-
+ epilog:
+    if (has_error) return NULL;
     Py_XINCREF(iter);
     return iter;
 }


### PR DESCRIPTION
Hi, I started using your code to script updates to our kerberos server and I find it very convenient.  For create_principal, I needed to pass a db option to say where to store it in our LDAP database (I am using a "x" keyword argument for that purpose, like the -x option in the kadmin tool).

As I was looking over the code, it seemed to me that it would often leak memory when using PyKAdmin_RETURN_ERROR.  So I tried to fix that too.