### PR TITLE
remove extra kadmin incref statements

### DIFF
--- a/PyKAdminPrincipalObject.c
+++ b/PyKAdminPrincipalObject.c
@@ -978,7 +978,6 @@ PyKAdminPrincipalObject *PyKAdminPrincipalObject_principal_with_name(PyKAdminObj
         }
     }
 
-    Py_INCREF(principal);
     return principal;
 }
 
@@ -1001,7 +1000,6 @@ PyKAdminPrincipalObject *PyKAdminPrincipalObject_principal_with_db_entry(PyKAdmi
         } 
     }
 
-    Py_XINCREF(principal);
     return principal;
 }
 

--- a/kadmin.c
+++ b/kadmin.c
@@ -347,7 +347,6 @@ static PyKAdminObject *_kadmin_init_with_ccache(PyObject *self, PyObject *args) 
 
     if (retval != KADM5_OK) { PyKAdmin_RETURN_ERROR(retval, "kadm5_init_with_creds"); }
 
-    Py_XINCREF(kadmin);
     return kadmin;
 }
 
@@ -356,6 +355,7 @@ static PyKAdminObject *_kadmin_init_with_ccache(PyObject *self, PyObject *args) 
 static PyKAdminObject *_kadmin_init_with_keytab(PyObject *self, PyObject *args) {
 
     PyKAdminObject *kadmin = PyKAdminObject_create();
+
     PyObject *db_args_dict = NULL;
     kadm5_ret_t retval = KADM5_OK;
     krb5_error_code code = 0;
@@ -404,9 +404,6 @@ static PyKAdminObject *_kadmin_init_with_keytab(PyObject *self, PyObject *args) 
 
     if (retval != KADM5_OK) { PyKAdmin_RETURN_ERROR(retval, "kadm5_init_with_skey"); }
 
-
-
-    Py_XINCREF(kadmin);
     return kadmin;
 }
 
@@ -444,7 +441,6 @@ static PyKAdminObject *_kadmin_init_with_password(PyObject *self, PyObject *args
 
     if (retval != KADM5_OK) { PyKAdmin_RETURN_ERROR(retval, "kadm5_init_with_password"); }
 
-    Py_XINCREF(kadmin);
     return kadmin;
 
 }


### PR DESCRIPTION
This patch removes extra incref statements which caused kadmin handles to hold server file descriptors until the interpreter exited. 

TODO: review reference counting for the remainder of the code base
