### PR TITLE
move the db_args parse routines to the common library in prep for ank/mo...

### DIFF
--- a/PyKAdminCommon.h
+++ b/PyKAdminCommon.h
@@ -9,6 +9,7 @@
 #include <krb5/krb5.h>
 #include <string.h>
 
+#include "pykadmin.h"
 #include "PyKAdminXDR.h"
 #include "PyKAdminObject.h"
 #include <bytesobject.h>
@@ -34,14 +35,29 @@ int pykadmin_seconds_from_pydatetime(PyObject *delta);
 char *pykadmin_timestamp_as_isodate(time_t timestamp, const char *zero);
 char *pykadmin_timestamp_as_deltastr(int seconds, const char *zero);
 
-
-
 krb5_error_code pykadmin_kadm_from_kdb(PyKAdminObject *kadmin, krb5_db_entry *kdb, kadm5_principal_ent_rec *entry, long mask); 
 
 krb5_error_code pykadmin_policy_kadm_from_osa(krb5_context ctx, osa_policy_ent_rec *osa, kadm5_policy_ent_rec *entry, long mask); 
 
 int pykadmin_principal_ent_rec_compare(krb5_context ctx, kadm5_principal_ent_rec *a, kadm5_principal_ent_rec *b);
 int pykadmin_policy_ent_rec_compare(krb5_context ctx, kadm5_policy_ent_rec *a, kadm5_policy_ent_rec *b);
+
+
+
+/* db_args */
+
+void pykadmin_append_tl_data(krb5_int16 *n_tl_datap, krb5_tl_data **tl_datap,
+            krb5_int16 tl_type, krb5_ui_2 len, krb5_octet *contents);
+
+// this call will handle parsing, tl_data copy, and freeing the db_args. 
+//  resulting tl_data will be freed by the call to kadm5_free_principal_ent()
+
+void pykadmin_principal_append_db_args(kadm5_principal_ent_rec *entry, PyObject *object);
+
+char **pykadmin_parse_db_args(PyObject *args);
+void pykadmin_free_db_args(char **db_args);
+
+
 
 
 // TODO

--- a/test/kldap/cn_config.ldif
+++ b/test/kldap/cn_config.ldif
@@ -1,0 +1,9 @@
+dn: cn=config
+objectClass: olcGlobal
+cn: config
+olcPidFile: /var/run/openldap/slapd.pid
+olcLogFile: /var/log/openldap/slapd.log
+olcTLSVerifyClient: try
+olcPasswordHash: {SSHA}
+olcThreads: 16
+olcToolThreads: 8

--- a/test/kldap/cn_module.ldif
+++ b/test/kldap/cn_module.ldif
@@ -1,0 +1,9 @@
+dn: cn=module,cn=config
+changetype: add
+objectClass: olcModuleList
+cn: module
+olcModulePath: /usr/lib64/openldap
+olcModuleLoad: syncprov.la
+olcModuleLoad: memberof.la
+olcModuleLoad: accesslog.la
+olcModuleLoad: back_ldap.la

--- a/test/kldap/dit.ldif
+++ b/test/kldap/dit.ldif
@@ -1,0 +1,59 @@
+
+
+dn: dc=example,dc=com
+objectClass: top
+objectClass: dcObject
+objectClass: organization
+o: Example Company
+dc: example
+
+dn: ou=people,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: people
+
+dn: uid=russell,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+uid: russell
+cn: Russell J Jancewicz
+userPassword: password
+sn: Jancewicz
+
+dn: uid=steven,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+uid: steven
+cn: Steven User
+userPassword: password
+sn: User
+
+dn: ou=accounts,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: accounts
+
+dn: ou=kerberos,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: kerberos
+
+dn: uid=kadmin,ou=accounts,dc=example,dc=com
+objectClass: top
+objectClass: account
+objectClass: simpleSecurityObject
+uid: kadmin
+userPassword: KADMIND_PASSWORD
+
+dn: uid=krb5kdc,ou=accounts,dc=example,dc=com
+objectClass: top
+objectClass: account
+objectClass: simpleSecurityObject
+uid: krb5kdc
+userPassword: KRB5KDC_PASSWORD
+
+

--- a/test/kldap/kdb_create.expect
+++ b/test/kldap/kdb_create.expect
@@ -1,0 +1,15 @@
+#!/usr/bin/expect
+
+set timeout -1
+spawn $env(SHELL)
+match_max 100000
+send -- "/usr/sbin/kdb5_ldap_util -D cn=root,dc=example,dc=com -w MDB_ROOT -H ldapi:/// create -subtrees dc=example,dc=com -r EXAMPLE.COM -s"
+expect -exact "/usr/sbin/kdb5_ldap_util -D cn=root,dc=example,dc=com -w MDB_ROOT -H ldapi:/// create -subtrees dc=example,dc=com -r EXAMPLE.COM -s"
+send -- "\r"
+expect "Enter KDC database master key: "
+send -- "MASTER_PASSWORD\r"
+expect "Re-enter KDC database master key to verify: "
+send -- "MASTER_PASSWORD\r"
+expect "\r"
+send -- "exit\r"
+expect eof

--- a/test/kldap/krb5.conf
+++ b/test/kldap/krb5.conf
@@ -1,0 +1,33 @@
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ default_realm = EXAMPLE.COM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h 
+ renew_lifetime = 7d
+ forwardable = true
+
+[realms]
+ EXAMPLE.COM = { 
+  kdc = kerberos.example.com
+  admin_server = kerberos.example.com
+  database_module = openldap
+ }
+
+[domain_realm]
+ .example.com = EXAMPLE.COM
+ example.com = EXAMPLE.COM
+
+[dbmodules]
+  openldap = {
+    db_library = kldap
+    ldap_servers = ldapi:///
+    ldap_kerberos_container_dn = dc=example,dc=com
+    ldap_kdc_dn = uid=krb5kdc,ou=accounts,dc=example,dc=com
+    ldap_kadmind_dn = uid=kadmin,ou=accounts,dc=example,dc=com
+    ldap_service_password_file = /var/kerberos/krb5kdc/.ldap.EXAMPLE.COM
+  }

--- a/test/kldap/ldap.conf
+++ b/test/kldap/ldap.conf
@@ -1,0 +1,16 @@
+#
+# LDAP Defaults
+#
+
+# See ldap.conf(5) for details
+# This file should be world readable but not world writable.
+
+BASE	dc=example,dc=com
+URI	    ldapi:///
+SASL_MECH EXTERNAL
+
+#SIZELIMIT	12
+#TIMELIMIT	15
+#DEREF		never
+
+TLS_CACERTDIR	/etc/openldap/certs

--- a/test/kldap/ldap_kdb.expect
+++ b/test/kldap/ldap_kdb.expect
@@ -1,0 +1,15 @@
+#!/usr/bin/expect
+
+set timeout -1
+spawn $env(SHELL)
+match_max 100000
+send -- "/usr/sbin/kdb5_util create -s"
+expect -exact "/usr/sbin/kdb5_util create -s"
+send -- "\r"
+expect "Enter KDC database master key: "
+send -- "y4xfpgb4\r"
+expect "Re-enter KDC database master key to verify: "
+send -- "y4xfpgb4\r"
+expect "\r"
+send -- "exit\r"
+expect eof 

--- a/test/kldap/olcDatabase_0.ldif
+++ b/test/kldap/olcDatabase_0.ldif
@@ -1,0 +1,8 @@
+dn: olcDatabase={0}config,cn=config
+objectClass: olcDatabaseConfig
+olcDatabase: {0}config
+olcRootPW: CONFIG_ROOT
+olcAccess: to attrs=olcRootPW by none
+olcAccess: to *
+  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage
+  by * none

--- a/test/kldap/olcDatabase_mdb.ldif
+++ b/test/kldap/olcDatabase_mdb.ldif
@@ -1,0 +1,26 @@
+# {1}mdb, config
+dn: olcDatabase={1}mdb,cn=config
+changetype: add
+objectClass: olcDatabaseConfig
+objectClass: olcMdbConfig
+olcDatabase: mdb
+olcDbDirectory: /srv/ldap/example.com
+olcSuffix: dc=example,dc=com
+olcRootDN: cn=root,dc=example,dc=com
+olcRootPW: MDB_ROOT
+olcLimits: dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" time=unlimited size=unlimited
+olcDbIndex: default pres,eq
+olcDbIndex: objectClass,entryCSN,entryUUID eq
+olcDbIndex: uid,krbPrincipalName eq,sub,subinitial,subany,subfinal
+#
+olcAccess: to * by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage 
+  by dn.exact="uid=kadmin,ou=accounts,dc=example,dc=com" write
+  by dn.exact="uid=krb5kdc,ou=accounts,dc=example,dc=com" write
+  by * break
+olcAccess: to dn.base="dc=example,dc=com" by * read
+olcAccess: to attrs=entry by dn.children="ou=accounts,dc=example,dc=com" read by * break
+olcAccess: to attrs=userPassword,krbPrincipalName,authzfrom,authzto by anonymous auth by * break
+#
+olcDbCheckpoint: 512 30
+olcDbMaxsize: 17179869184
+olcDbNoSync: FALSE

--- a/test/kldap/schema/collective.ldif
+++ b/test/kldap/schema/collective.ldif
@@ -1,0 +1,48 @@
+# collective.ldif -- Collective attribute schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (2003).
+## Please see full copyright statement below.
+#
+# From RFC 3671 [portions trimmed]:
+# 	Collective Attributes in LDAP
+#
+# This file was automatically generated from collective.schema; see that file
+# for complete references.
+#
+dn: cn=collective,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: collective
+olcAttributeTypes: {0}( 2.5.4.7.1 NAME 'c-l' SUP l COLLECTIVE )
+olcAttributeTypes: {1}( 2.5.4.8.1 NAME 'c-st' SUP st COLLECTIVE )
+olcAttributeTypes: {2}( 2.5.4.9.1 NAME 'c-street' SUP street COLLECTIVE )
+olcAttributeTypes: {3}( 2.5.4.10.1 NAME 'c-o' SUP o COLLECTIVE )
+olcAttributeTypes: {4}( 2.5.4.11.1 NAME 'c-ou' SUP ou COLLECTIVE )
+olcAttributeTypes: {5}( 2.5.4.16.1 NAME 'c-PostalAddress' SUP postalAddress CO
+ LLECTIVE )
+olcAttributeTypes: {6}( 2.5.4.17.1 NAME 'c-PostalCode' SUP postalCode COLLECTI
+ VE )
+olcAttributeTypes: {7}( 2.5.4.18.1 NAME 'c-PostOfficeBox' SUP postOfficeBox CO
+ LLECTIVE )
+olcAttributeTypes: {8}( 2.5.4.19.1 NAME 'c-PhysicalDeliveryOfficeName' SUP phy
+ sicalDeliveryOfficeName COLLECTIVE )
+olcAttributeTypes: {9}( 2.5.4.20.1 NAME 'c-TelephoneNumber' SUP telephoneNumbe
+ r COLLECTIVE )
+olcAttributeTypes: {10}( 2.5.4.21.1 NAME 'c-TelexNumber' SUP telexNumber COLLE
+ CTIVE )
+olcAttributeTypes: {11}( 2.5.4.23.1 NAME 'c-FacsimileTelephoneNumber' SUP facs
+ imileTelephoneNumber COLLECTIVE )
+olcAttributeTypes: {12}( 2.5.4.25.1 NAME 'c-InternationalISDNNumber' SUP inter
+ nationalISDNNumber COLLECTIVE )

--- a/test/kldap/schema/corba.ldif
+++ b/test/kldap/schema/corba.ldif
@@ -1,0 +1,42 @@
+# corba.ldif -- Corba Object Schema
+#	depends upon core.ldif
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (1999).
+## Please see full copyright statement below.
+#
+# From RFC 2714 [portions trimmed]:
+#   Schema for Representing CORBA Object References in an LDAP Directory
+#
+# This file was automatically generated from corba.schema; see that file
+# for complete references.
+#
+dn: cn=corba,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: corba
+olcAttributeTypes: {0}( 1.3.6.1.4.1.42.2.27.4.1.14 NAME 'corbaIor' DESC 'Strin
+ gified interoperable object reference of a CORBA object' EQUALITY caseIgnoreI
+ A5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+olcAttributeTypes: {1}( 1.3.6.1.4.1.42.2.27.4.1.15 NAME 'corbaRepositoryId' DE
+ SC 'Repository ids of interfaces implemented by a CORBA object' EQUALITY case
+ ExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcObjectClasses: {0}( 1.3.6.1.4.1.42.2.27.4.2.10 NAME 'corbaContainer' DESC '
+ Container for a CORBA object' SUP top STRUCTURAL MUST cn )
+olcObjectClasses: {1}( 1.3.6.1.4.1.42.2.27.4.2.9 NAME 'corbaObject' DESC 'CORB
+ A object representation' SUP top ABSTRACT MAY ( corbaRepositoryId $ descripti
+ on ) )
+olcObjectClasses: {2}( 1.3.6.1.4.1.42.2.27.4.2.11 NAME 'corbaObjectReference' 
+ DESC 'CORBA interoperable object reference' SUP corbaObject AUXILIARY MUST co
+ rbaIor )

--- a/test/kldap/schema/core.ldif
+++ b/test/kldap/schema/core.ldif
@@ -1,0 +1,591 @@
+# OpenLDAP Core schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (1997-2003).
+## All Rights Reserved.
+##
+## This document and translations of it may be copied and furnished to
+## others, and derivative works that comment on or otherwise explain it
+## or assist in its implementation may be prepared, copied, published
+## and distributed, in whole or in part, without restriction of any
+## kind, provided that the above copyright notice and this paragraph are
+## included on all such copies and derivative works.  However, this
+## document itself may not be modified in any way, such as by removing
+## the copyright notice or references to the Internet Society or other
+## Internet organizations, except as needed for the purpose of
+## developing Internet standards in which case the procedures for
+## copyrights defined in the Internet Standards process must be         
+## followed, or as required to translate it into languages other than
+## English.
+##                                                                      
+## The limited permissions granted above are perpetual and will not be  
+## revoked by the Internet Society or its successors or assigns.        
+## 
+## This document and the information contained herein is provided on an 
+## "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+## TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+## BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+## HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+## MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+#
+#
+# Includes LDAPv3 schema items from:
+#	RFC 2252/2256 (LDAPv3)
+#
+# Select standard track schema items:
+#	RFC 1274 (uid/dc)
+#	RFC 2079 (URI)
+#	RFC 2247 (dc/dcObject)
+#	RFC 2587 (PKI)
+#	RFC 2589 (Dynamic Directory Services)
+#
+# Select informational schema items:
+#	RFC 2377 (uidObject)
+#
+#
+# Standard attribute types from RFC 2256
+#
+dn: cn=core,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: core
+#
+# system schema
+#olcAttributeTypes: ( 2.5.4.0 NAME 'objectClass'
+#	DESC 'RFC2256: object classes of the entity'
+#	EQUALITY objectIdentifierMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 )
+#
+# system schema
+#olcAttributeTypes: ( 2.5.4.1 NAME ( 'aliasedObjectName' 'aliasedEntryName' )
+#	DESC 'RFC2256: name of aliased object'
+#	EQUALITY distinguishedNameMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE )
+#
+olcAttributeTypes: ( 2.5.4.2 NAME 'knowledgeInformation'
+  DESC 'RFC2256: knowledge information'
+  EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768} )
+#
+# system schema
+#olcAttributeTypes: ( 2.5.4.3 NAME ( 'cn' 'commonName' )
+#	DESC 'RFC2256: common name(s) for which the entity is known by'
+#	SUP name )
+#
+olcAttributeTypes: ( 2.5.4.4 NAME ( 'sn' 'surname' )
+  DESC 'RFC2256: last (family) name(s) for which the entity is known by'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.5 NAME 'serialNumber'
+  DESC 'RFC2256: serial number of the entity'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.44{64} )
+#
+# RFC 4519 definition ('countryName' in X.500 and RFC2256)
+olcAttributeTypes: ( 2.5.4.6 NAME ( 'c' 'countryName' )
+  DESC 'RFC4519: two-letter ISO-3166 country code'
+  SUP name
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.11
+  SINGLE-VALUE )
+#
+olcAttributeTypes: ( 2.5.4.7 NAME ( 'l' 'localityName' )
+  DESC 'RFC2256: locality which this object resides in'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.8 NAME ( 'st' 'stateOrProvinceName' )
+  DESC 'RFC2256: state or province which this object resides in'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.9 NAME ( 'street' 'streetAddress' )
+  DESC 'RFC2256: street address of this object'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128} )
+#
+olcAttributeTypes: ( 2.5.4.10 NAME ( 'o' 'organizationName' )
+  DESC 'RFC2256: organization this object belongs to'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.11 NAME ( 'ou' 'organizationalUnitName' )
+  DESC 'RFC2256: organizational unit this object belongs to'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.12 NAME 'title'
+  DESC 'RFC2256: title associated with the entity'
+  SUP name )
+#
+# system schema
+#olcAttributeTypes: ( 2.5.4.13 NAME 'description'
+#	DESC 'RFC2256: descriptive information'
+#	EQUALITY caseIgnoreMatch
+#	SUBSTR caseIgnoreSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
+#
+# Deprecated by enhancedSearchGuide
+olcAttributeTypes: ( 2.5.4.14 NAME 'searchGuide'
+  DESC 'RFC2256: search guide, deprecated by enhancedSearchGuide'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.25 )
+#
+olcAttributeTypes: ( 2.5.4.15 NAME 'businessCategory'
+  DESC 'RFC2256: business category'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128} )
+#
+olcAttributeTypes: ( 2.5.4.16 NAME 'postalAddress'
+  DESC 'RFC2256: postal address'
+  EQUALITY caseIgnoreListMatch
+  SUBSTR caseIgnoreListSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 )
+#
+olcAttributeTypes: ( 2.5.4.17 NAME 'postalCode'
+  DESC 'RFC2256: postal code'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40} )
+#
+olcAttributeTypes: ( 2.5.4.18 NAME 'postOfficeBox'
+  DESC 'RFC2256: Post Office Box'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40} )
+#
+olcAttributeTypes: ( 2.5.4.19 NAME 'physicalDeliveryOfficeName'
+  DESC 'RFC2256: Physical Delivery Office Name'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128} )
+#
+olcAttributeTypes: ( 2.5.4.20 NAME 'telephoneNumber'
+  DESC 'RFC2256: Telephone Number'
+  EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.50{32} )
+#
+olcAttributeTypes: ( 2.5.4.21 NAME 'telexNumber'
+  DESC 'RFC2256: Telex Number'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.52 )
+#
+olcAttributeTypes: ( 2.5.4.22 NAME 'teletexTerminalIdentifier'
+  DESC 'RFC2256: Teletex Terminal Identifier'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.51 )
+#
+olcAttributeTypes: ( 2.5.4.23 NAME ( 'facsimileTelephoneNumber' 'fax' )
+  DESC 'RFC2256: Facsimile (Fax) Telephone Number'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.22 )
+#
+olcAttributeTypes: ( 2.5.4.24 NAME 'x121Address'
+  DESC 'RFC2256: X.121 Address'
+  EQUALITY numericStringMatch
+  SUBSTR numericStringSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.36{15} )
+#
+olcAttributeTypes: ( 2.5.4.25 NAME 'internationaliSDNNumber'
+  DESC 'RFC2256: international ISDN number'
+  EQUALITY numericStringMatch
+  SUBSTR numericStringSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.36{16} )
+#
+olcAttributeTypes: ( 2.5.4.26 NAME 'registeredAddress'
+  DESC 'RFC2256: registered postal address'
+  SUP postalAddress
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 )
+#
+olcAttributeTypes: ( 2.5.4.27 NAME 'destinationIndicator'
+  DESC 'RFC2256: destination indicator'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.44{128} )
+#
+olcAttributeTypes: ( 2.5.4.28 NAME 'preferredDeliveryMethod'
+  DESC 'RFC2256: preferred delivery method'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.14
+  SINGLE-VALUE )
+#
+olcAttributeTypes: ( 2.5.4.29 NAME 'presentationAddress'
+  DESC 'RFC2256: presentation address'
+  EQUALITY presentationAddressMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.43
+  SINGLE-VALUE )
+#
+olcAttributeTypes: ( 2.5.4.30 NAME 'supportedApplicationContext'
+  DESC 'RFC2256: supported application context'
+  EQUALITY objectIdentifierMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 )
+#
+olcAttributeTypes: ( 2.5.4.31 NAME 'member'
+  DESC 'RFC2256: member of a group'
+  SUP distinguishedName )
+#
+olcAttributeTypes: ( 2.5.4.32 NAME 'owner'
+  DESC 'RFC2256: owner (of the object)'
+  SUP distinguishedName )
+#
+olcAttributeTypes: ( 2.5.4.33 NAME 'roleOccupant'
+  DESC 'RFC2256: occupant of role'
+  SUP distinguishedName )
+#
+# system schema
+#olcAttributeTypes: ( 2.5.4.34 NAME 'seeAlso'
+#	DESC 'RFC2256: DN of related object'
+#	SUP distinguishedName )
+#
+# system schema
+#olcAttributeTypes: ( 2.5.4.35 NAME 'userPassword'
+#	DESC 'RFC2256/2307: password of user'
+#	EQUALITY octetStringMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.40{128} )
+#
+# Must be transferred using ;binary
+# with certificateExactMatch rule (per X.509)
+olcAttributeTypes: ( 2.5.4.36 NAME 'userCertificate'
+  DESC 'RFC2256: X.509 user certificate, use ;binary'
+  EQUALITY certificateExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 )
+#
+# Must be transferred using ;binary
+# with certificateExactMatch rule (per X.509)
+olcAttributeTypes: ( 2.5.4.37 NAME 'cACertificate'
+  DESC 'RFC2256: X.509 CA certificate, use ;binary'
+  EQUALITY certificateExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 )
+#
+# Must be transferred using ;binary
+olcAttributeTypes: ( 2.5.4.38 NAME 'authorityRevocationList'
+  DESC 'RFC2256: X.509 authority revocation list, use ;binary'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 )
+#
+# Must be transferred using ;binary
+olcAttributeTypes: ( 2.5.4.39 NAME 'certificateRevocationList'
+  DESC 'RFC2256: X.509 certificate revocation list, use ;binary'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 )
+#
+# Must be stored and requested in the binary form
+olcAttributeTypes: ( 2.5.4.40 NAME 'crossCertificatePair'
+  DESC 'RFC2256: X.509 cross certificate pair, use ;binary'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.10 )
+#
+# 2.5.4.41 is defined above as it's used for subtyping
+#olcAttributeTypes: ( 2.5.4.41 NAME 'name'
+#	EQUALITY caseIgnoreMatch
+#	SUBSTR caseIgnoreSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768} )
+#
+olcAttributeTypes: ( 2.5.4.42 NAME ( 'givenName' 'gn' )
+  DESC 'RFC2256: first name(s) for which the entity is known by'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.43 NAME 'initials'
+  DESC 'RFC2256: initials of some or all of names, but not the surname(s).'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.44 NAME 'generationQualifier'
+  DESC 'RFC2256: name qualifier indicating a generation'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.45 NAME 'x500UniqueIdentifier'
+  DESC 'RFC2256: X.500 unique identifier'
+  EQUALITY bitStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.6 )
+#
+olcAttributeTypes: ( 2.5.4.46 NAME 'dnQualifier'
+  DESC 'RFC2256: DN qualifier'
+  EQUALITY caseIgnoreMatch
+  ORDERING caseIgnoreOrderingMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.44 )
+#
+olcAttributeTypes: ( 2.5.4.47 NAME 'enhancedSearchGuide'
+  DESC 'RFC2256: enhanced search guide'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.21 )
+#
+olcAttributeTypes: ( 2.5.4.48 NAME 'protocolInformation'
+  DESC 'RFC2256: protocol information'
+  EQUALITY protocolInformationMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.42 )
+#
+# 2.5.4.49 is defined above as it's used for subtyping
+#olcAttributeTypes: ( 2.5.4.49 NAME 'distinguishedName'
+#	EQUALITY distinguishedNameMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+#
+olcAttributeTypes: ( 2.5.4.50 NAME 'uniqueMember'
+  DESC 'RFC2256: unique member of a group'
+  EQUALITY uniqueMemberMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.34 )
+#
+olcAttributeTypes: ( 2.5.4.51 NAME 'houseIdentifier'
+  DESC 'RFC2256: house identifier'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768} )
+#
+# Must be transferred using ;binary
+olcAttributeTypes: ( 2.5.4.52 NAME 'supportedAlgorithms'
+  DESC 'RFC2256: supported algorithms'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.49 )
+#
+# Must be transferred using ;binary
+olcAttributeTypes: ( 2.5.4.53 NAME 'deltaRevocationList'
+  DESC 'RFC2256: delta revocation list; use ;binary'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 )
+#
+olcAttributeTypes: ( 2.5.4.54 NAME 'dmdName'
+  DESC 'RFC2256: name of DMD'
+  SUP name )
+#
+olcAttributeTypes: ( 2.5.4.65 NAME 'pseudonym'
+  DESC 'X.520(4th): pseudonym for the object'
+  SUP name )
+#
+# Standard object classes from RFC2256
+#
+# system schema
+#olcObjectClasses: ( 2.5.6.1 NAME 'alias'
+#	DESC 'RFC2256: an alias'
+#	SUP top STRUCTURAL
+#	MUST aliasedObjectName )
+#
+olcObjectClasses: ( 2.5.6.2 NAME 'country'
+  DESC 'RFC2256: a country'
+  SUP top STRUCTURAL
+  MUST c
+  MAY ( searchGuide $ description ) )
+#
+olcObjectClasses: ( 2.5.6.3 NAME 'locality'
+  DESC 'RFC2256: a locality'
+  SUP top STRUCTURAL
+  MAY ( street $ seeAlso $ searchGuide $ st $ l $ description ) )
+#
+olcObjectClasses: ( 2.5.6.4 NAME 'organization'
+  DESC 'RFC2256: an organization'
+  SUP top STRUCTURAL
+  MUST o
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $
+  x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ 
+  facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+  postalAddress $ physicalDeliveryOfficeName $ st $ l $ description ) )
+#
+olcObjectClasses: ( 2.5.6.5 NAME 'organizationalUnit'
+  DESC 'RFC2256: an organizational unit'
+  SUP top STRUCTURAL
+  MUST ou
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $
+  x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $
+  facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+  postalAddress $ physicalDeliveryOfficeName $ st $ l $ description ) )
+#
+olcObjectClasses: ( 2.5.6.6 NAME 'person'
+  DESC 'RFC2256: a person'
+  SUP top STRUCTURAL
+  MUST ( sn $ cn )
+  MAY ( userPassword $ telephoneNumber $ seeAlso $ description ) )
+#
+olcObjectClasses: ( 2.5.6.7 NAME 'organizationalPerson'
+  DESC 'RFC2256: an organizational person'
+  SUP person STRUCTURAL
+  MAY ( title $ x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ 
+  facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+  postalAddress $ physicalDeliveryOfficeName $ ou $ st $ l ) )
+#
+olcObjectClasses: ( 2.5.6.8 NAME 'organizationalRole'
+  DESC 'RFC2256: an organizational role'
+  SUP top STRUCTURAL
+  MUST cn
+  MAY ( x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+  seeAlso $ roleOccupant $ preferredDeliveryMethod $ street $
+  postOfficeBox $ postalCode $ postalAddress $
+  physicalDeliveryOfficeName $ ou $ st $ l $ description ) )
+#
+olcObjectClasses: ( 2.5.6.9 NAME 'groupOfNames'
+  DESC 'RFC2256: a group of names (DNs)'
+  SUP top STRUCTURAL
+  MUST ( member $ cn )
+  MAY ( businessCategory $ seeAlso $ owner $ ou $ o $ description ) )
+#
+olcObjectClasses: ( 2.5.6.10 NAME 'residentialPerson'
+  DESC 'RFC2256: an residential person'
+  SUP person STRUCTURAL
+  MUST l
+  MAY ( businessCategory $ x121Address $ registeredAddress $
+  destinationIndicator $ preferredDeliveryMethod $ telexNumber $
+  teletexTerminalIdentifier $ telephoneNumber $ internationaliSDNNumber $
+  facsimileTelephoneNumber $ preferredDeliveryMethod $ street $
+  postOfficeBox $ postalCode $ postalAddress $
+  physicalDeliveryOfficeName $ st $ l ) )
+#
+olcObjectClasses: ( 2.5.6.11 NAME 'applicationProcess'
+  DESC 'RFC2256: an application process'
+  SUP top STRUCTURAL
+  MUST cn
+  MAY ( seeAlso $ ou $ l $ description ) )
+#
+olcObjectClasses: ( 2.5.6.12 NAME 'applicationEntity'
+  DESC 'RFC2256: an application entity'
+  SUP top STRUCTURAL
+  MUST ( presentationAddress $ cn )
+  MAY ( supportedApplicationContext $ seeAlso $ ou $ o $ l $
+  description ) )
+#
+olcObjectClasses: ( 2.5.6.13 NAME 'dSA'
+  DESC 'RFC2256: a directory system agent (a server)'
+  SUP applicationEntity STRUCTURAL
+  MAY knowledgeInformation )
+#
+olcObjectClasses: ( 2.5.6.14 NAME 'device'
+  DESC 'RFC2256: a device'
+  SUP top STRUCTURAL
+  MUST cn
+  MAY ( serialNumber $ seeAlso $ owner $ ou $ o $ l $ description ) )
+#
+olcObjectClasses: ( 2.5.6.15 NAME 'strongAuthenticationUser'
+  DESC 'RFC2256: a strong authentication user'
+  SUP top AUXILIARY
+  MUST userCertificate )
+#
+olcObjectClasses: ( 2.5.6.16 NAME 'certificationAuthority'
+  DESC 'RFC2256: a certificate authority'
+  SUP top AUXILIARY
+  MUST ( authorityRevocationList $ certificateRevocationList $
+  cACertificate ) MAY crossCertificatePair )
+#
+olcObjectClasses: ( 2.5.6.17 NAME 'groupOfUniqueNames'
+  DESC 'RFC2256: a group of unique names (DN and Unique Identifier)'
+  SUP top STRUCTURAL
+  MUST ( uniqueMember $ cn )
+  MAY ( businessCategory $ seeAlso $ owner $ ou $ o $ description ) )
+#
+olcObjectClasses: ( 2.5.6.18 NAME 'userSecurityInformation'
+  DESC 'RFC2256: a user security information'
+  SUP top AUXILIARY
+  MAY ( supportedAlgorithms ) )
+#
+olcObjectClasses: ( 2.5.6.16.2 NAME 'certificationAuthority-V2'
+  SUP certificationAuthority
+  AUXILIARY MAY ( deltaRevocationList ) )
+#
+olcObjectClasses: ( 2.5.6.19 NAME 'cRLDistributionPoint'
+  SUP top STRUCTURAL
+  MUST ( cn )
+  MAY ( certificateRevocationList $ authorityRevocationList $
+  deltaRevocationList ) )
+#
+olcObjectClasses: ( 2.5.6.20 NAME 'dmd'
+  SUP top STRUCTURAL
+  MUST ( dmdName )
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $
+  x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+  street $ postOfficeBox $ postalCode $ postalAddress $
+  physicalDeliveryOfficeName $ st $ l $ description ) )
+#
+#
+# Object Classes from RFC 2587
+#
+olcObjectClasses: ( 2.5.6.21 NAME 'pkiUser'
+  DESC 'RFC2587: a PKI user'
+  SUP top AUXILIARY
+  MAY userCertificate )
+#
+olcObjectClasses: ( 2.5.6.22 NAME 'pkiCA'
+  DESC 'RFC2587: PKI certificate authority'
+  SUP top AUXILIARY
+  MAY ( authorityRevocationList $ certificateRevocationList $
+  cACertificate $ crossCertificatePair ) )
+#
+olcObjectClasses: ( 2.5.6.23 NAME 'deltaCRL'
+  DESC 'RFC2587: PKI user'
+  SUP top AUXILIARY
+  MAY deltaRevocationList )
+#
+#
+# Standard Track URI label schema from RFC 2079
+# system schema
+#olcAttributeTypes: ( 1.3.6.1.4.1.250.1.57 NAME 'labeledURI'
+#	DESC 'RFC2079: Uniform Resource Identifier with optional label'
+#	EQUALITY caseExactMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+olcObjectClasses: ( 1.3.6.1.4.1.250.3.15 NAME 'labeledURIObject'
+  DESC 'RFC2079: object that contains the URI attribute type'
+  MAY ( labeledURI )
+  SUP top AUXILIARY )
+#
+#
+# Derived from RFC 1274, but with new "short names"
+#
+#olcAttributeTypes: ( 0.9.2342.19200300.100.1.1
+#	NAME ( 'uid' 'userid' )
+#	DESC 'RFC1274: user identifier'
+#	EQUALITY caseIgnoreMatch
+#	SUBSTR caseIgnoreSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.3
+  NAME ( 'mail' 'rfc822Mailbox' )
+  DESC 'RFC1274: RFC822 Mailbox'
+    EQUALITY caseIgnoreIA5Match
+    SUBSTR caseIgnoreIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+#
+olcObjectClasses: ( 0.9.2342.19200300.100.4.19 NAME 'simpleSecurityObject'
+  DESC 'RFC1274: simple security object'
+  SUP top AUXILIARY
+  MUST userPassword )
+#
+# RFC 1274 + RFC 2247
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.25
+  NAME ( 'dc' 'domainComponent' )
+  DESC 'RFC1274/2247: domain component'
+  EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+#
+# RFC 2247
+olcObjectClasses: ( 1.3.6.1.4.1.1466.344 NAME 'dcObject'
+  DESC 'RFC2247: domain component object'
+  SUP top AUXILIARY MUST dc )
+#
+# RFC 2377
+olcObjectClasses: ( 1.3.6.1.1.3.1 NAME 'uidObject'
+  DESC 'RFC2377: uid object'
+  SUP top AUXILIARY MUST uid )
+#
+# From COSINE Pilot
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.37
+  NAME 'associatedDomain'
+  DESC 'RFC1274: domain associated with object'
+  EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+#
+# RFC 2459 -- deprecated in favor of 'mail' (in cosine.schema)
+olcAttributeTypes: ( 1.2.840.113549.1.9.1
+  NAME ( 'email' 'emailAddress' 'pkcs9email' )
+  DESC 'RFC3280: legacy attribute for email addresses in DNs'
+  EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+#

--- a/test/kldap/schema/cosine.ldif
+++ b/test/kldap/schema/cosine.ldif
@@ -1,0 +1,200 @@
+# RFC1274: Cosine and Internet X.500 schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# RFC1274: Cosine and Internet X.500 schema
+#
+# This file contains LDAPv3 schema derived from X.500 COSINE "pilot"
+# schema.  As this schema was defined for X.500(89), some
+# oddities were introduced in the mapping to LDAPv3.  The
+# mappings were based upon: draft-ietf-asid-ldapv3-attributes-03.txt
+# (a work in progress)
+#
+# Note: It seems that the pilot schema evolved beyond what was
+# described in RFC1274.  However, this document attempts to describes
+# RFC1274 as published.
+#
+# Depends on core.ldif
+#
+# This file was automatically generated from cosine.schema; see that
+# file for complete background.
+#
+dn: cn=cosine,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: cosine
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.2 NAME 'textEncodedORAddress' 
+ EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.
+ 1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.4 NAME 'info' DESC 'RFC1274: g
+ eneral information' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{2048} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.5 NAME ( 'drink' 'favouriteDri
+ nk' ) DESC 'RFC1274: favorite drink' EQUALITY caseIgnoreMatch SUBSTR caseIgno
+ reSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.6 NAME 'roomNumber' DESC 'RFC1
+ 274: room number' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch S
+ YNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.7 NAME 'photo' DESC 'RFC1274: 
+ photo (G3 fax)' SYNTAX 1.3.6.1.4.1.1466.115.121.1.23{25000} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.8 NAME 'userClass' DESC 'RFC12
+ 74: category of user' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMat
+ ch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.9 NAME 'host' DESC 'RFC1274: h
+ ost computer' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTA
+ X 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.10 NAME 'manager' DESC 'RFC127
+ 4: DN of manager' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115
+ .121.1.12 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.11 NAME 'documentIdentifier' D
+ ESC 'RFC1274: unique identifier of document' EQUALITY caseIgnoreMatch SUBSTR 
+ caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.12 NAME 'documentTitle' DESC '
+ RFC1274: title of document' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstri
+ ngsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.13 NAME 'documentVersion' DES
+ C 'RFC1274: version of document' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSu
+ bstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.14 NAME 'documentAuthor' DESC
+  'RFC1274: DN of author of document' EQUALITY distinguishedNameMatch SYNTAX 1
+ .3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.15 NAME 'documentLocation' DE
+ SC 'RFC1274: location of document original' EQUALITY caseIgnoreMatch SUBSTR c
+ aseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.20 NAME ( 'homePhone' 'homeTe
+ lephoneNumber' ) DESC 'RFC1274: home telephone number' EQUALITY telephoneNumb
+ erMatch SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121
+ .1.50 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.21 NAME 'secretary' DESC 'RFC
+ 1274: DN of secretary' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.146
+ 6.115.121.1.12 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.22 NAME 'otherMailbox' SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.39 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.26 NAME 'aRecord' EQUALITY ca
+ seIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.27 NAME 'mDRecord' EQUALITY c
+ aseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.28 NAME 'mXRecord' EQUALITY c
+ aseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.29 NAME 'nSRecord' EQUALITY c
+ aseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.30 NAME 'sOARecord' EQUALITY 
+ caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.31 NAME 'cNAMERecord' EQUALIT
+ Y caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.38 NAME 'associatedName' DESC
+  'RFC1274: DN of entry associated with domain' EQUALITY distinguishedNameMatc
+ h SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.39 NAME 'homePostalAddress' D
+ ESC 'RFC1274: home postal address' EQUALITY caseIgnoreListMatch SUBSTR caseIg
+ noreListSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.40 NAME 'personalTitle' DESC 
+ 'RFC1274: personal title' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstring
+ sMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.41 NAME ( 'mobile' 'mobileTel
+ ephoneNumber' ) DESC 'RFC1274: mobile telephone number' EQUALITY telephoneNum
+ berMatch SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.12
+ 1.1.50 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.42 NAME ( 'pager' 'pagerTelep
+ honeNumber' ) DESC 'RFC1274: pager telephone number' EQUALITY telephoneNumber
+ Match SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1
+ .50 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.43 NAME ( 'co' 'friendlyCount
+ ryName' ) DESC 'RFC1274: friendly country name' EQUALITY caseIgnoreMatch SUBS
+ TR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.44 NAME 'uniqueIdentifier' DE
+ SC 'RFC1274: unique identifer' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.14
+ 66.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.45 NAME 'organizationalStatus
+ ' DESC 'RFC1274: organizational status' EQUALITY caseIgnoreMatch SUBSTR caseI
+ gnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.46 NAME 'janetMailbox' DESC '
+ RFC1274: Janet mailbox' EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5Subst
+ ringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.47 NAME 'mailPreferenceOption
+ ' DESC 'RFC1274: mail preference option' SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.48 NAME 'buildingName' DESC '
+ RFC1274: name of building' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstrin
+ gsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.49 NAME 'dSAQuality' DESC 'RF
+ C1274: DSA Quality' SYNTAX 1.3.6.1.4.1.1466.115.121.1.19 SINGLE-VALUE )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.50 NAME 'singleLevelQuality' 
+ DESC 'RFC1274: Single Level Quality' SYNTAX 1.3.6.1.4.1.1466.115.121.1.13 SIN
+ GLE-VALUE )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.51 NAME 'subtreeMinimumQualit
+ y' DESC 'RFC1274: Subtree Mininum Quality' SYNTAX 1.3.6.1.4.1.1466.115.121.1.
+ 13 SINGLE-VALUE )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.52 NAME 'subtreeMaximumQualit
+ y' DESC 'RFC1274: Subtree Maximun Quality' SYNTAX 1.3.6.1.4.1.1466.115.121.1.
+ 13 SINGLE-VALUE )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.53 NAME 'personalSignature' D
+ ESC 'RFC1274: Personal Signature (G3 fax)' SYNTAX 1.3.6.1.4.1.1466.115.121.1.
+ 23 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.54 NAME 'dITRedirect' DESC 'R
+ FC1274: DIT Redirect' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466
+ .115.121.1.12 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.55 NAME 'audio' DESC 'RFC1274
+ : audio (u-law)' SYNTAX 1.3.6.1.4.1.1466.115.121.1.4{25000} )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.56 NAME 'documentPublisher' D
+ ESC 'RFC1274: publisher of document' EQUALITY caseIgnoreMatch SUBSTR caseIgno
+ reSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.4 NAME ( 'pilotPerson' 'newPilo
+ tPerson' ) SUP person STRUCTURAL MAY ( userid $ textEncodedORAddress $ rfc822
+ Mailbox $ favouriteDrink $ roomNumber $ userClass $ homeTelephoneNumber $ hom
+ ePostalAddress $ secretary $ personalTitle $ preferredDeliveryMethod $ busine
+ ssCategory $ janetMailbox $ otherMailbox $ mobileTelephoneNumber $ pagerTelep
+ honeNumber $ organizationalStatus $ mailPreferenceOption $ personalSignature 
+ ) )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.5 NAME 'account' SUP top STRUCT
+ URAL MUST userid MAY ( description $ seeAlso $ localityName $ organizationNam
+ e $ organizationalUnitName $ host ) )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.6 NAME 'document' SUP top STRUC
+ TURAL MUST documentIdentifier MAY ( commonName $ description $ seeAlso $ loca
+ lityName $ organizationName $ organizationalUnitName $ documentTitle $ docume
+ ntVersion $ documentAuthor $ documentLocation $ documentPublisher ) )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.7 NAME 'room' SUP top STRUCTURA
+ L MUST commonName MAY ( roomNumber $ description $ seeAlso $ telephoneNumber 
+ ) )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.9 NAME 'documentSeries' SUP top
+  STRUCTURAL MUST commonName MAY ( description $ seeAlso $ telephonenumber $ l
+ ocalityName $ organizationName $ organizationalUnitName ) )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.13 NAME 'domain' SUP top STRUCT
+ URAL MUST domainComponent MAY ( associatedName $ organizationName $ descripti
+ on $ businessCategory $ seeAlso $ searchGuide $ userPassword $ localityName $
+  stateOrProvinceName $ streetAddress $ physicalDeliveryOfficeName $ postalAdd
+ ress $ postalCode $ postOfficeBox $ streetAddress $ facsimileTelephoneNumber 
+ $ internationalISDNNumber $ telephoneNumber $ teletexTerminalIdentifier $ tel
+ exNumber $ preferredDeliveryMethod $ destinationIndicator $ registeredAddress
+  $ x121Address ) )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.14 NAME 'RFC822localPart' SUP d
+ omain STRUCTURAL MAY ( commonName $ surname $ description $ seeAlso $ telepho
+ neNumber $ physicalDeliveryOfficeName $ postalAddress $ postalCode $ postOffi
+ ceBox $ streetAddress $ facsimileTelephoneNumber $ internationalISDNNumber $ 
+ telephoneNumber $ teletexTerminalIdentifier $ telexNumber $ preferredDelivery
+ Method $ destinationIndicator $ registeredAddress $ x121Address ) )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.15 NAME 'dNSDomain' SUP domain 
+ STRUCTURAL MAY ( ARecord $ MDRecord $ MXRecord $ NSRecord $ SOARecord $ CNAME
+ Record ) )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.17 NAME 'domainRelatedObject' D
+ ESC 'RFC1274: an object related to an domain' SUP top AUXILIARY MUST associat
+ edDomain )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.18 NAME 'friendlyCountry' SUP c
+ ountry STRUCTURAL MUST friendlyCountryName )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.20 NAME 'pilotOrganization' SU
+ P ( organization $ organizationalUnit ) STRUCTURAL MAY buildingName )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.21 NAME 'pilotDSA' SUP dsa STR
+ UCTURAL MAY dSAQuality )
+olcObjectClasses: ( 0.9.2342.19200300.100.4.22 NAME 'qualityLabelledData' 
+ SUP top AUXILIARY MUST dsaQuality MAY ( subtreeMinimumQuality $ subtreeMaximu
+ mQuality ) )

--- a/test/kldap/schema/duaconf.ldif
+++ b/test/kldap/schema/duaconf.ldif
@@ -1,0 +1,83 @@
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# DUA schema from draft-joslin-config-schema (a work in progress)
+#
+# This file was automatically generated from duaconf.schema; see that file
+# for complete references.
+#
+dn: cn=duaconf,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: duaconf
+olcObjectIdentifier: {0}DUAConfSchemaOID 1.3.6.1.4.1.11.1.3.1
+olcAttributeTypes: {0}( DUAConfSchemaOID:1.0 NAME 'defaultServerList' DESC 'De
+ fault LDAP server host address used by a DUA' EQUALITY caseIgnoreMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
+olcAttributeTypes: {1}( DUAConfSchemaOID:1.1 NAME 'defaultSearchBase' DESC 'De
+ fault LDAP base DN used by a DUA' EQUALITY distinguishedNameMatch SYNTAX 1.3.
+ 6.1.4.1.1466.115.121.1.12 SINGLE-VALUE )
+olcAttributeTypes: {2}( DUAConfSchemaOID:1.2 NAME 'preferredServerList' DESC '
+ Preferred LDAP server host addresses to be used by a            DUA' EQUALITY
+  caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
+olcAttributeTypes: {3}( DUAConfSchemaOID:1.3 NAME 'searchTimeLimit' DESC 'Maxi
+ mum time in seconds a DUA should allow for a            search to complete' E
+ QUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {4}( DUAConfSchemaOID:1.4 NAME 'bindTimeLimit' DESC 'Maximu
+ m time in seconds a DUA should allow for the            bind operation to com
+ plete' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALU
+ E )
+olcAttributeTypes: {5}( DUAConfSchemaOID:1.5 NAME 'followReferrals' DESC 'Tell
+ s DUA if it should follow referrals            returned by a DSA search resul
+ t' EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE )
+olcAttributeTypes: {6}( DUAConfSchemaOID:1.16 NAME 'dereferenceAliases' DESC '
+ Tells DUA if it should dereference aliases' EQUALITY booleanMatch SYNTAX 1.3.
+ 6.1.4.1.1466.115.121.1.7 SINGLE-VALUE )
+olcAttributeTypes: {7}( DUAConfSchemaOID:1.6 NAME 'authenticationMethod' DESC 
+ 'A keystring which identifies the type of            authentication method us
+ ed to contact the DSA' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.1
+ 21.1.15 SINGLE-VALUE )
+olcAttributeTypes: {8}( DUAConfSchemaOID:1.7 NAME 'profileTTL' DESC 'Time to l
+ ive, in seconds, before a client DUA            should re-read this configura
+ tion profile' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SING
+ LE-VALUE )
+olcAttributeTypes: {9}( DUAConfSchemaOID:1.14 NAME 'serviceSearchDescriptor' D
+ ESC 'LDAP search descriptor list used by a DUA' EQUALITY caseExactMatch SYNTA
+ X 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {10}( DUAConfSchemaOID:1.9 NAME 'attributeMap' DESC 'Attrib
+ ute mappings used by a DUA' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.14
+ 66.115.121.1.26 )
+olcAttributeTypes: {11}( DUAConfSchemaOID:1.10 NAME 'credentialLevel' DESC 'Id
+ entifies type of credentials a DUA should            use when binding to the 
+ LDAP server' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE )
+olcAttributeTypes: {12}( DUAConfSchemaOID:1.11 NAME 'objectclassMap' DESC 'Obj
+ ectclass mappings used by a DUA' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4
+ .1.1466.115.121.1.26 )
+olcAttributeTypes: {13}( DUAConfSchemaOID:1.12 NAME 'defaultSearchScope' DESC 
+ 'Default search scope used by a DUA' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6
+ .1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+olcAttributeTypes: {14}( DUAConfSchemaOID:1.13 NAME 'serviceCredentialLevel' D
+ ESC 'Identifies type of credentials a DUA            should use when binding 
+ to the LDAP server for a            specific service' EQUALITY caseIgnoreIA5M
+ atch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: {15}( DUAConfSchemaOID:1.15 NAME 'serviceAuthenticationMeth
+ od' DESC 'Authentication method used by a service of the DUA' EQUALITY caseIg
+ noreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcObjectClasses: {0}( DUAConfSchemaOID:2.5 NAME 'DUAConfigProfile' DESC 'Abst
+ raction of a base configuration for a DUA' SUP top STRUCTURAL MUST cn MAY ( d
+ efaultServerList $ preferredServerList $ defaultSearchBase $ defaultSearchSco
+ pe $ searchTimeLimit $ bindTimeLimit $ credentialLevel $ authenticationMethod
+  $ followReferrals $ dereferenceAliases $ serviceSearchDescriptor $ serviceCr
+ edentialLevel $ serviceAuthenticationMethod $ objectclassMap $ attributeMap $
+  profileTTL ) )

--- a/test/kldap/schema/dyngroup.ldif
+++ b/test/kldap/schema/dyngroup.ldif
@@ -1,0 +1,71 @@
+# dyngroup.schema -- Dynamic Group schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# Dynamic Group schema (experimental), as defined by Netscape.  See
+# http://www.redhat.com/docs/manuals/ent-server/pdf/esadmin611.pdf
+# page 70 for details on how these groups were used.
+#
+# A description of the objectclass definition is available here:
+# http://www.redhat.com/docs/manuals/dir-server/schema/7.1/oc_dir.html#1303745
+#
+# depends upon:
+#       core.schema
+#
+# These definitions are considered experimental due to the lack of
+# a formal specification (e.g., RFC).
+#
+# NOT RECOMMENDED FOR PRODUCTION USE!  USE WITH CAUTION!
+#
+# The Netscape documentation describes this as an auxiliary objectclass
+# but their implementations have always defined it as a structural class.
+# The sloppiness here is because Netscape-derived servers don't actually
+# implement the X.500 data model, and they don't honor the distinction
+# between structural and auxiliary classes. This fact is noted here:
+# http://forum.java.sun.com/thread.jspa?threadID=5016864&messageID=9034636
+#
+# In accordance with other existing implementations, we define it as a
+# structural class.
+#
+# Our definition of memberURL also does not match theirs but again
+# their published definition and what works in practice do not agree.
+# In other words, the Netscape definitions are broken and interoperability
+# is not guaranteed.
+#
+# Also see the new DynGroup proposed spec at
+# http://tools.ietf.org/html/draft-haripriya-dynamicgroup-02
+dn: cn=dyngroup,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: dyngroup
+olcObjectIdentifier: {0}NetscapeRoot 2.16.840.1.113730
+olcObjectIdentifier: {1}NetscapeLDAP NetscapeRoot:3
+olcObjectIdentifier: {2}NetscapeLDAPattributeType NetscapeLDAP:1
+olcObjectIdentifier: {3}NetscapeLDAPobjectClass NetscapeLDAP:2
+olcObjectIdentifier: {4}OpenLDAPExp11 1.3.6.1.4.1.4203.666.11
+olcObjectIdentifier: {5}DynGroupBase OpenLDAPExp11:8
+olcObjectIdentifier: {6}DynGroupAttr DynGroupBase:1
+olcObjectIdentifier: {7}DynGroupOC DynGroupBase:2
+olcAttributeTypes: {0}( NetscapeLDAPattributeType:198 NAME 'memberURL' DESC 'I
+ dentifies an URL associated with each member of a group. Any type of labeled 
+ URL can be used.' SUP labeledURI )
+olcAttributeTypes: {1}( DynGroupAttr:1 NAME 'dgIdentity' DESC 'Identity to use
+  when processing the memberURL' SUP distinguishedName SINGLE-VALUE )
+olcAttributeTypes: {2}( DynGroupAttr:2 NAME 'dgAuthz' DESC 'Optional authoriza
+ tion rules that determine who is allowed to assume the dgIdentity' EQUALITY a
+ uthzMatch SYNTAX 1.3.6.1.4.1.4203.666.2.7 X-ORDERED 'VALUES' )
+olcObjectClasses: {0}( NetscapeLDAPobjectClass:33 NAME 'groupOfURLs' SUP top S
+ TRUCTURAL MUST cn MAY ( memberURL $ businessCategory $ description $ o $ ou $
+  owner $ seeAlso ) )
+olcObjectClasses: {1}( DynGroupOC:1 NAME 'dgIdentityAux' SUP top AUXILIARY MAY
+  ( dgIdentity $ dgAuthz ) )

--- a/test/kldap/schema/eduorg.ldif
+++ b/test/kldap/schema/eduorg.ldif
@@ -1,0 +1,22 @@
+# mace-dir, schema, config
+dn: cn=eduorg,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: eduorg
+olcAttributeTypes: {0}( 1.3.6.1.4.1.5923.1.2.1.2  NAME 'eduOrgHomePageURI' DES
+ C 'eduOrg per Internet2 and EDUCAUSE' EQUALITY caseExactMatch SYNTAX '1.3.6.1
+ .4.1.1466.115.121.1.15' )
+olcAttributeTypes: {1}( 1.3.6.1.4.1.5923.1.2.1.3  NAME 'eduOrgIdentityAuthNPol
+ icyURI' DESC 'eduOrg per Internet2 and EDUCAUSE' EQUALITY caseExactMatch SYNT
+ AX '1.3.6.1.4.1.1466.115.121.1.15' )
+olcAttributeTypes: {2}( 1.3.6.1.4.1.5923.1.2.1.4  NAME 'eduOrgLegalName' DESC 
+ 'eduOrg per Internet2 and EDUCAUSE' EQUALITY caseIgnoreMatch SYNTAX '1.3.6.1.
+ 4.1.1466.115.121.1.15' )
+olcAttributeTypes: {3}( 1.3.6.1.4.1.5923.1.2.1.5  NAME 'eduOrgSuperiorURI' DES
+ C 'eduOrg per Internet2 and EDUCAUSE' EQUALITY caseExactMatch SYNTAX '1.3.6.1
+ .4.1.1466.115.121.1.15' )
+olcAttributeTypes: {4}( 1.3.6.1.4.1.5923.1.2.1.6 NAME 'eduOrgWhitePagesURI' DE
+ SC 'eduOrg per Internet2 and EDUCAUSE' EQUALITY caseExactMatch SYNTAX '1.3.6.
+ 1.4.1.1466.115.121.1.15' )
+olcObjectClasses: {0}( 1.3.6.1.4.1.5923.1.2.2NAME 'eduOrg' AUXILIARY MAY ( cn 
+ $ eduOrgHomePageURI $   eduOrgIdentityAuthNPolicyURI $ eduOrgLegalName $   ed
+ uOrgSuperiorURI $ eduOrgWhitePagesURI ))

--- a/test/kldap/schema/eduperson.ldif
+++ b/test/kldap/schema/eduperson.ldif
@@ -1,0 +1,45 @@
+# mace-dir, schema, config
+dn: cn=eduperson,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: eduperson
+olcAttributeTypes: {0}( 1.3.6.1.4.1.5923.1.1.1.1 NAME 'eduPersonAffiliation' D
+ ESC 'eduPerson per Internet2 and EDUCAUSE' EQUALITY caseIgnoreMatch SUBSTR ca
+ seIgnoreSubstringsMatch SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+olcAttributeTypes: {1}( 1.3.6.1.4.1.5923.1.1.1.2 NAME 'eduPersonNickname' DESC
+  'eduPerson per Internet2 and EDUCAUSE' EQUALITY caseIgnoreMatch SUBSTR caseI
+ gnoreSubstringsMatch SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+olcAttributeTypes: {2}( 1.3.6.1.4.1.5923.1.1.1.3 NAME 'eduPersonOrgDN' DESC 'e
+ duPerson per Internet2 and EDUCAUSE' EQUALITY distinguishedNameMatch SYNTAX '
+ 1.3.6.1.4.1.1466.115.121.1.12' SINGLE-VALUE )
+olcAttributeTypes: {3}( 1.3.6.1.4.1.5923.1.1.1.4 NAME 'eduPersonOrgUnitDN' DES
+ C 'eduPerson per Internet2 and EDUCAUSE' EQUALITY distinguishedNameMatch SYNT
+ AX '1.3.6.1.4.1.1466.115.121.1.12' )
+olcAttributeTypes: {4}( 1.3.6.1.4.1.5923.1.1.1.5 NAME 'eduPersonPrimaryAffilia
+ tion' DESC 'eduPerson per Internet2 and EDUCAUSE' EQUALITY caseIgnoreMatch SU
+ BSTR caseIgnoreSubstringsMatch SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' SINGLE-
+ VALUE )
+olcAttributeTypes: {5}( 1.3.6.1.4.1.5923.1.1.1.6 NAME 'eduPersonPrincipalName'
+  DESC 'eduPerson per Internet2 and EDUCAUSE' EQUALITY caseIgnoreMatch SUBSTR 
+ caseIgnoreSubstringsMatch SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' SINGLE-VALUE
+  )
+olcAttributeTypes: {6}( 1.3.6.1.4.1.5923.1.1.1.7 NAME 'eduPersonEntitlement' D
+ ESC 'eduPerson per Internet2 and EDUCAUSE' EQUALITY caseExactMatch SYNTAX '1.
+ 3.6.1.4.1.1466.115.121.1.15' )
+olcAttributeTypes: {7}( 1.3.6.1.4.1.5923.1.1.1.8 NAME 'eduPersonPrimaryOrgUnit
+ DN' DESC 'eduPerson per Internet2 and EDUCAUSE' EQUALITY distinguishedNameMat
+ ch SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' SINGLE-VALUE )
+olcAttributeTypes: {8}( 1.3.6.1.4.1.5923.1.1.1.9 NAME 'eduPersonScopedAffiliat
+ ion' DESC 'eduPerson per Internet2 and EDUCAUSE' EQUALITY caseIgnoreMatch SYN
+ TAX '1.3.6.1.4.1.1466.115.121.1.15' )
+olcAttributeTypes: {9}( 1.3.6.1.4.1.5923.1.1.1.10 NAME 'eduPersonTargetedID' D
+ ESC 'eduPerson per Internet2 and EDUCAUSE' EQUALITY caseIgnoreMatch SYNTAX '1
+ .3.6.1.4.1.1466.115.121.1.15' )
+olcAttributeTypes: {10}( 1.3.6.1.4.1.5923.1.1.1.11 NAME 'eduPersonAssurance' D
+ ESC 'eduPerson per Internet2 and EDUCAUSE' EQUALITY caseIgnoreMatch SYNTAX '1
+ .3.6.1.4.1.1466.115.121.1.15' )
+olcObjectClasses: {0}( 1.3.6.1.4.1.5923.1.1.2 NAME 'eduPerson' DESC 'eduPerson
+  per Internet2 and EDUCAUSE' AUXILIARY MAY ( eduPersonAffiliation $ eduPerson
+ Nickname $ eduPersonOrgDN $    eduPersonOrgUnitDN $ eduPersonPrimaryAffiliati
+ on $   eduPersonPrincipalName $ eduPersonEntitlement $   eduPersonPrimaryOrgU
+ nitDN $ eduPersonScopedAffiliation $   eduPersonTargetedID $ eduPersonAssuran
+ ce ))

--- a/test/kldap/schema/inetorgperson.ldif
+++ b/test/kldap/schema/inetorgperson.ldif
@@ -1,0 +1,69 @@
+# InetOrgPerson (RFC2798)
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# InetOrgPerson (RFC2798)
+#
+# Depends upon
+#   Definition of an X.500 Attribute Type and an Object Class to Hold
+#   Uniform Resource Identifiers (URIs) [RFC2079]
+#	(core.ldif)
+#
+#   A Summary of the X.500(96) User Schema for use with LDAPv3 [RFC2256]
+#	(core.ldif)
+#
+#   The COSINE and Internet X.500 Schema [RFC1274] (cosine.ldif)
+#
+# This file was automatically generated from inetorgperson.schema; see
+# that file for complete references.
+#
+dn: cn=inetorgperson,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: inetorgperson
+olcAttributeTypes: ( 2.16.840.1.113730.3.1.1 NAME 'carLicense' DESC 'RFC279
+ 8: vehicle license or registration plate' EQUALITY caseIgnoreMatch SUBSTR cas
+ eIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 2.16.840.1.113730.3.1.2 NAME 'departmentNumber' DESC '
+ RFC2798: identifies a department within an organization' EQUALITY caseIgnoreM
+ atch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 2.16.840.1.113730.3.1.241 NAME 'displayName' DESC 'RFC
+ 2798: preferred name to be used when displaying entries' EQUALITY caseIgnoreM
+ atch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SI
+ NGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.3.1.3 NAME 'employeeNumber' DESC 'RF
+ C2798: numerically identifies an employee within an organization' EQUALITY ca
+ seIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.12
+ 1.1.15 SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.3.1.4 NAME 'employeeType' DESC 'RFC2
+ 798: type of employment for a person' EQUALITY caseIgnoreMatch SUBSTR caseIgn
+ oreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 0.9.2342.19200300.100.1.60 NAME 'jpegPhoto' DESC 'RFC2
+ 798: a JPEG image' SYNTAX 1.3.6.1.4.1.1466.115.121.1.28 )
+olcAttributeTypes: ( 2.16.840.1.113730.3.1.39 NAME 'preferredLanguage' DESC
+  'RFC2798: preferred written or spoken language for a person' EQUALITY caseIg
+ noreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.
+ 15 SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.3.1.40 NAME 'userSMIMECertificate' D
+ ESC 'RFC2798: PKCS#7 SignedData used to support S/MIME' SYNTAX 1.3.6.1.4.1.14
+ 66.115.121.1.5 )
+olcAttributeTypes: ( 2.16.840.1.113730.3.1.216 NAME 'userPKCS12' DESC 'RFC2
+ 798: personal identity information, a PKCS #12 PFX' SYNTAX 1.3.6.1.4.1.1466.1
+ 15.121.1.5 )
+olcObjectClasses: ( 2.16.840.1.113730.3.2.2 NAME 'inetOrgPerson' DESC 'RFC2
+ 798: Internet Organizational Person' SUP organizationalPerson STRUCTURAL MAY 
+ ( audio $ businessCategory $ carLicense $ departmentNumber $ displayName $ em
+ ployeeNumber $ employeeType $ givenName $ homePhone $ homePostalAddress $ ini
+ tials $ jpegPhoto $ labeledURI $ mail $ manager $ mobile $ o $ pager $ photo 
+ $ roomNumber $ secretary $ uid $ userCertificate $ x500uniqueIdentifier $ pre
+ ferredLanguage $ userSMIMECertificate $ userPKCS12 ) )

--- a/test/kldap/schema/java.ldif
+++ b/test/kldap/schema/java.ldif
@@ -1,0 +1,59 @@
+# java.ldif -- Java Object Schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# Java Object Schema (defined in RFC 2713)
+#	depends upon core.ldif
+#
+# This file was automatically generated from java.schema; see that file
+# for complete references.
+#
+dn: cn=java,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: java
+olcAttributeTypes: {0}( 1.3.6.1.4.1.42.2.27.4.1.6 NAME 'javaClassName' DESC 'F
+ ully qualified name of distinguished Java class or interface' EQUALITY caseEx
+ actMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
+olcAttributeTypes: {1}( 1.3.6.1.4.1.42.2.27.4.1.7 NAME 'javaCodebase' DESC 'UR
+ L(s) specifying the location of class definition' EQUALITY caseExactIA5Match 
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: {2}( 1.3.6.1.4.1.42.2.27.4.1.13 NAME 'javaClassNames' DESC 
+ 'Fully qualified Java class or interface name' EQUALITY caseExactMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {3}( 1.3.6.1.4.1.42.2.27.4.1.8 NAME 'javaSerializedData' DE
+ SC 'Serialized form of a Java object' SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SI
+ NGLE-VALUE )
+olcAttributeTypes: {4}( 1.3.6.1.4.1.42.2.27.4.1.10 NAME 'javaFactory' DESC 'Fu
+ lly qualified Java class name of a JNDI object factory' EQUALITY caseExactMat
+ ch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
+olcAttributeTypes: {5}( 1.3.6.1.4.1.42.2.27.4.1.11 NAME 'javaReferenceAddress'
+  DESC 'Addresses associated with a JNDI Reference' EQUALITY caseExactMatch SY
+ NTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {6}( 1.3.6.1.4.1.42.2.27.4.1.12 NAME 'javaDoc' DESC 'The Ja
+ va documentation for the class' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1
+ .1466.115.121.1.26 )
+olcObjectClasses: {0}( 1.3.6.1.4.1.42.2.27.4.2.1 NAME 'javaContainer' DESC 'Co
+ ntainer for a Java object' SUP top STRUCTURAL MUST cn )
+olcObjectClasses: {1}( 1.3.6.1.4.1.42.2.27.4.2.4 NAME 'javaObject' DESC 'Java 
+ object representation' SUP top ABSTRACT MUST javaClassName MAY ( javaClassNam
+ es $ javaCodebase $ javaDoc $ description ) )
+olcObjectClasses: {2}( 1.3.6.1.4.1.42.2.27.4.2.5 NAME 'javaSerializedObject' D
+ ESC 'Java serialized object' SUP javaObject AUXILIARY MUST javaSerializedData
+  )
+olcObjectClasses: {3}( 1.3.6.1.4.1.42.2.27.4.2.8 NAME 'javaMarshalledObject' D
+ ESC 'Java marshalled object' SUP javaObject AUXILIARY MUST javaSerializedData
+  )
+olcObjectClasses: {4}( 1.3.6.1.4.1.42.2.27.4.2.7 NAME 'javaNamingReference' DE
+ SC 'JNDI reference' SUP javaObject AUXILIARY MAY ( javaReferenceAddress $ jav
+ aFactory ) )

--- a/test/kldap/schema/kerberos.ldif
+++ b/test/kldap/schema/kerberos.ldif
@@ -1,0 +1,153 @@
+
+dn: cn=kerberos,cn=schema,cn=config 
+objectClass: olcSchemaConfig
+cn: kerberos
+olcAttributeTypes: {0}( 2.16.840.1.113719.1.301.4.1.1 NAME 'krbPrincipalName' 
+ EQUALITY caseExactIA5Match SUBSTR caseExactSubstringsMatch SYNTAX 1.3.6.1.4.1
+ .1466.115.121.1.26 )
+olcAttributeTypes: {1}( 1.2.840.113554.1.4.1.6.1 NAME 'krbCanonicalName' EQUAL
+ ITY caseExactIA5Match SUBSTR caseExactSubstringsMatch SYNTAX 1.3.6.1.4.1.1466
+ .115.121.1.26 SINGLE-VALUE )
+olcAttributeTypes: {2}( 2.16.840.1.113719.1.301.4.3.1 NAME 'krbPrincipalType' 
+ EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {3}( 2.16.840.1.113719.1.301.4.5.1 NAME 'krbUPEnabled' DESC
+  'Boolean' SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE )
+olcAttributeTypes: {4}( 2.16.840.1.113719.1.301.4.6.1 NAME 'krbPrincipalExpira
+ tion' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SING
+ LE-VALUE )
+olcAttributeTypes: {5}( 2.16.840.1.113719.1.301.4.8.1 NAME 'krbTicketFlags' EQ
+ UALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {6}( 2.16.840.1.113719.1.301.4.9.1 NAME 'krbMaxTicketLife' 
+ EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {7}( 2.16.840.1.113719.1.301.4.10.1 NAME 'krbMaxRenewableAg
+ e' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {8}( 2.16.840.1.113719.1.301.4.14.1 NAME 'krbRealmReference
+ s' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: {9}( 2.16.840.1.113719.1.301.4.15.1 NAME 'krbLdapServers' E
+ QUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {10}( 2.16.840.1.113719.1.301.4.17.1 NAME 'krbKdcServers' E
+ QUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: {11}( 2.16.840.1.113719.1.301.4.18.1 NAME 'krbPwdServers' E
+ QUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: {12}( 2.16.840.1.113719.1.301.4.24.1 NAME 'krbHostServer' E
+ QUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: {13}( 2.16.840.1.113719.1.301.4.25.1 NAME 'krbSearchScope' 
+ EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {14}( 2.16.840.1.113719.1.301.4.26.1 NAME 'krbPrincipalRefe
+ rences' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 
+ )
+olcAttributeTypes: {15}( 2.16.840.1.113719.1.301.4.28.1 NAME 'krbPrincNamingAt
+ tr' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALU
+ E )
+olcAttributeTypes: {16}( 2.16.840.1.113719.1.301.4.29.1 NAME 'krbAdmServers' E
+ QUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: {17}( 2.16.840.1.113719.1.301.4.30.1 NAME 'krbMaxPwdLife' E
+ QUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {18}( 2.16.840.1.113719.1.301.4.31.1 NAME 'krbMinPwdLife' E
+ QUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {19}( 2.16.840.1.113719.1.301.4.32.1 NAME 'krbPwdMinDiffCha
+ rs' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {20}( 2.16.840.1.113719.1.301.4.33.1 NAME 'krbPwdMinLength'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {21}( 2.16.840.1.113719.1.301.4.34.1 NAME 'krbPwdHistoryLen
+ gth' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE 
+ )
+olcAttributeTypes: {22}( 1.3.6.1.4.1.5322.21.2.1 NAME 'krbPwdMaxFailure' EQUAL
+ ITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {23}( 1.3.6.1.4.1.5322.21.2.2 NAME 'krbPwdFailureCountInter
+ val' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE 
+ )
+olcAttributeTypes: {24}( 1.3.6.1.4.1.5322.21.2.3 NAME 'krbPwdLockoutDuration' 
+ EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {25}( 1.2.840.113554.1.4.1.6.2 NAME 'krbPwdAttributes' EQUA
+ LITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {26}( 1.2.840.113554.1.4.1.6.3 NAME 'krbPwdMaxLife' EQUALIT
+ Y integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {27}( 1.2.840.113554.1.4.1.6.4 NAME 'krbPwdMaxRenewableLife
+ ' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {28}( 1.2.840.113554.1.4.1.6.5 NAME 'krbPwdAllowedKeysalts'
+  EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALU
+ E )
+olcAttributeTypes: {29}( 2.16.840.1.113719.1.301.4.36.1 NAME 'krbPwdPolicyRefe
+ rence' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 S
+ INGLE-VALUE )
+olcAttributeTypes: {30}( 2.16.840.1.113719.1.301.4.37.1 NAME 'krbPasswordExpir
+ ation' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SIN
+ GLE-VALUE )
+olcAttributeTypes: {31}( 2.16.840.1.113719.1.301.4.39.1 NAME 'krbPrincipalKey'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+olcAttributeTypes: {32}( 2.16.840.1.113719.1.301.4.40.1 NAME 'krbTicketPolicyR
+ eference' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.1
+ 2 SINGLE-VALUE )
+olcAttributeTypes: {33}( 2.16.840.1.113719.1.301.4.41.1 NAME 'krbSubTrees' EQU
+ ALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: {34}( 2.16.840.1.113719.1.301.4.42.1 NAME 'krbDefaultEncSal
+ tTypes' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {35}( 2.16.840.1.113719.1.301.4.43.1 NAME 'krbSupportedEncS
+ altTypes' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {36}( 2.16.840.1.113719.1.301.4.44.1 NAME 'krbPwdHistory' E
+ QUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+olcAttributeTypes: {37}( 2.16.840.1.113719.1.301.4.45.1 NAME 'krbLastPwdChange
+ ' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SINGLE-V
+ ALUE )
+olcAttributeTypes: {38}( 1.3.6.1.4.1.5322.21.2.5 NAME 'krbLastAdminUnlock' EQU
+ ALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SINGLE-VALUE 
+ )
+olcAttributeTypes: {39}( 2.16.840.1.113719.1.301.4.46.1 NAME 'krbMKey' EQUALIT
+ Y octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+olcAttributeTypes: {40}( 2.16.840.1.113719.1.301.4.47.1 NAME 'krbPrincipalAlia
+ ses' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: {41}( 2.16.840.1.113719.1.301.4.48.1 NAME 'krbLastSuccessfu
+ lAuth' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SIN
+ GLE-VALUE )
+olcAttributeTypes: {42}( 2.16.840.1.113719.1.301.4.49.1 NAME 'krbLastFailedAut
+ h' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SINGLE-
+ VALUE )
+olcAttributeTypes: {43}( 2.16.840.1.113719.1.301.4.50.1 NAME 'krbLoginFailedCo
+ unt' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE 
+ )
+olcAttributeTypes: {44}( 2.16.840.1.113719.1.301.4.51.1 NAME 'krbExtraData' EQ
+ UALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+olcAttributeTypes: {45}( 2.16.840.1.113719.1.301.4.52.1 NAME 'krbObjectReferen
+ ces' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: {46}( 2.16.840.1.113719.1.301.4.53.1 NAME 'krbPrincContaine
+ rRef' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+olcAttributeTypes: {47}( 1.3.6.1.4.1.5322.21.2.4 NAME 'krbAllowedToDelegateTo'
+  EQUALITY caseExactIA5Match SUBSTR caseExactSubstringsMatch SYNTAX 1.3.6.1.4.
+ 1.1466.115.121.1.26 )
+olcObjectClasses: {0}( 2.16.840.1.113719.1.301.6.1.1 NAME 'krbContainer' SUP t
+ op STRUCTURAL MUST cn )
+olcObjectClasses: {1}( 2.16.840.1.113719.1.301.6.2.1 NAME 'krbRealmContainer' 
+ SUP top STRUCTURAL MUST cn MAY ( krbMKey $ krbUPEnabled $ krbSubTrees $ krbSe
+ archScope $ krbLdapServers $ krbSupportedEncSaltTypes $ krbDefaultEncSaltType
+ s $ krbTicketPolicyReference $ krbKdcServers $ krbPwdServers $ krbAdmServers 
+ $ krbPrincNamingAttr $ krbPwdPolicyReference $ krbPrincContainerRef ) )
+olcObjectClasses: {2}( 2.16.840.1.113719.1.301.6.3.1 NAME 'krbService' SUP top
+  ABSTRACT MUST cn MAY ( krbHostServer $ krbRealmReferences ) )
+olcObjectClasses: {3}( 2.16.840.1.113719.1.301.6.4.1 NAME 'krbKdcService' SUP 
+ krbService STRUCTURAL )
+olcObjectClasses: {4}( 2.16.840.1.113719.1.301.6.5.1 NAME 'krbPwdService' SUP 
+ krbService STRUCTURAL )
+olcObjectClasses: {5}( 2.16.840.1.113719.1.301.6.8.1 NAME 'krbPrincipalAux' SU
+ P top AUXILIARY MAY ( krbPrincipalName $ krbCanonicalName $ krbUPEnabled $ kr
+ bPrincipalKey $ krbTicketPolicyReference $ krbPrincipalExpiration $ krbPasswo
+ rdExpiration $ krbPwdPolicyReference $ krbPrincipalType $ krbPwdHistory $ krb
+ LastPwdChange $ krbLastAdminUnlock $ krbPrincipalAliases $ krbLastSuccessfulA
+ uth $ krbLastFailedAuth $ krbLoginFailedCount $ krbExtraData $ krbAllowedToDe
+ legateTo ) )
+olcObjectClasses: {6}( 2.16.840.1.113719.1.301.6.9.1 NAME 'krbPrincipal' SUP t
+ op STRUCTURAL MUST krbPrincipalName MAY krbObjectReferences )
+olcObjectClasses: {7}( 2.16.840.1.113719.1.301.6.11.1 NAME 'krbPrincRefAux' SU
+ P top AUXILIARY MAY krbPrincipalReferences )
+olcObjectClasses: {8}( 2.16.840.1.113719.1.301.6.13.1 NAME 'krbAdmService' SUP
+  krbService STRUCTURAL )
+olcObjectClasses: {9}( 2.16.840.1.113719.1.301.6.14.1 NAME 'krbPwdPolicy' SUP 
+ top STRUCTURAL MUST cn MAY ( krbMaxPwdLife $ krbMinPwdLife $ krbPwdMinDiffCha
+ rs $ krbPwdMinLength $ krbPwdHistoryLength $ krbPwdMaxFailure $ krbPwdFailure
+ CountInterval $ krbPwdLockoutDuration $ krbPwdAttributes $ krbPwdMaxLife $ kr
+ bPwdMaxRenewableLife $ krbPwdAllowedKeysalts ) )
+olcObjectClasses: {10}( 2.16.840.1.113719.1.301.6.16.1 NAME 'krbTicketPolicyAu
+ x' SUP top AUXILIARY MAY ( krbTicketFlags $ krbMaxTicketLife $ krbMaxRenewabl
+ eAge ) )
+olcObjectClasses: {11}( 2.16.840.1.113719.1.301.6.17.1 NAME 'krbTicketPolicy' 
+ SUP top STRUCTURAL MUST cn )

--- a/test/kldap/schema/misc.ldif
+++ b/test/kldap/schema/misc.ldif
@@ -1,0 +1,45 @@
+# misc.ldif -- assorted schema definitions
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# Assorted definitions from several sources, including
+# ''works in progress''.  Contents of this file are
+# subject to change (including deletion) without notice.
+#
+# Not recommended for production use!
+# Use with extreme caution!
+#
+# This file was automatically generated from misc.schema; see that file
+# for complete references.
+#
+dn: cn=misc,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: misc
+olcAttributeTypes: {0}( 2.16.840.1.113730.3.1.13 NAME 'mailLocalAddress' DESC 
+ 'RFC822 email address of this recipient' EQUALITY caseIgnoreIA5Match SYNTAX 1
+ .3.6.1.4.1.1466.115.121.1.26{256} )
+olcAttributeTypes: {1}( 2.16.840.1.113730.3.1.18 NAME 'mailHost' DESC 'FQDN of
+  the SMTP/MTA of this recipient' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4
+ .1.1466.115.121.1.26{256} SINGLE-VALUE )
+olcAttributeTypes: {2}( 2.16.840.1.113730.3.1.47 NAME 'mailRoutingAddress' DES
+ C 'RFC822 routing address of this recipient' EQUALITY caseIgnoreIA5Match SYNT
+ AX 1.3.6.1.4.1.1466.115.121.1.26{256} SINGLE-VALUE )
+olcAttributeTypes: {3}( 1.3.6.1.4.1.42.2.27.2.1.15 NAME 'rfc822MailMember' DES
+ C 'rfc822 mail address of group member(s)' EQUALITY caseIgnoreIA5Match SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.26 )
+olcObjectClasses: {0}( 2.16.840.1.113730.3.2.147 NAME 'inetLocalMailRecipient'
+  DESC 'Internet local mail recipient' SUP top AUXILIARY MAY ( mailLocalAddres
+ s $ mailHost $ mailRoutingAddress ) )
+olcObjectClasses: {1}( 1.3.6.1.4.1.42.2.27.1.2.5 NAME 'nisMailAlias' DESC 'NIS
+  mail alias' SUP top STRUCTURAL MUST cn MAY rfc822MailMember )

--- a/test/kldap/schema/nis.ldif
+++ b/test/kldap/schema/nis.ldif
@@ -1,0 +1,120 @@
+# NIS (RFC2307)
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# Definitions from RFC2307 (Experimental)
+#	An Approach for Using LDAP as a Network Information Service
+#
+# Depends upon core.ldif and cosine.ldif
+#
+# This file was automatically generated from nis.schema; see that file
+# for complete references.
+#
+dn: cn=nis,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: nis
+olcAttributeTypes: ( 1.3.6.1.1.1.1.2 NAME 'gecos' DESC 'The GECOS field; th
+ e common name' EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatc
+ h SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory' DESC 'The absolut
+ e path to the home directory' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1
+ 466.115.121.1.26 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.4 NAME 'loginShell' DESC 'The path to th
+ e login shell' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.2
+ 6 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange' EQUALITY integ
+ erMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.6 NAME 'shadowMin' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.7 NAME 'shadowMax' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning' EQUALITY integerM
+ atch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive' EQUALITY integer
+ Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire' EQUALITY integerM
+ atch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag' EQUALITY integerMat
+ ch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.12 NAME 'memberUid' EQUALITY caseExactI
+ A5Match SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.
+ 26 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup' EQUALITY ca
+ seExactIA5Match SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.11
+ 5.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple' DESC 'Netgr
+ oup triple' SYNTAX 1.3.6.1.1.1.0.0 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort' EQUALITY intege
+ rMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol' SUP name )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber' EQUALITY int
+ egerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber' EQUALITY integer
+ Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber' DESC 'IP address
+ ' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber' DESC 'IP netw
+ ork' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} SI
+ NGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber' DESC 'IP netm
+ ask' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} SI
+ NGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.22 NAME 'macAddress' DESC 'MAC address'
+  EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.23 NAME 'bootParameter' DESC 'rpc.bootp
+ aramd parameter' SYNTAX 1.3.6.1.1.1.0.1 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.24 NAME 'bootFile' DESC 'Boot image nam
+ e' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.26 NAME 'nisMapName' SUP name )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry' EQUALITY caseExac
+ tIA5Match SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.
+ 1.26{1024} SINGLE-VALUE )
+olcObjectClasses: ( 1.3.6.1.1.1.2.0 NAME 'posixAccount' DESC 'Abstraction o
+ f an account with POSIX attributes' SUP top AUXILIARY MUST ( cn $ uid $ uidNu
+ mber $ gidNumber $ homeDirectory ) MAY ( userPassword $ loginShell $ gecos $ 
+ description ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' DESC 'Additional a
+ ttributes for shadow passwords' SUP top AUXILIARY MUST uid MAY ( userPassword
+  $ shadowLastChange $ shadowMin $ shadowMax $ shadowWarning $ shadowInactive 
+ $ shadowExpire $ shadowFlag $ description ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' DESC 'Abstraction of 
+ a group of accounts' SUP top STRUCTURAL MUST ( cn $ gidNumber ) MAY ( userPas
+ sword $ memberUid $ description ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.3 NAME 'ipService' DESC 'Abstraction an I
+ nternet Protocol service' SUP top STRUCTURAL MUST ( cn $ ipServicePort $ ipSe
+ rviceProtocol ) MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' DESC 'Abstraction of 
+ an IP protocol' SUP top STRUCTURAL MUST ( cn $ ipProtocolNumber $ description
+  ) MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.5 NAME 'oncRpc' DESC 'Abstraction of an O
+ NC/RPC binding' SUP top STRUCTURAL MUST ( cn $ oncRpcNumber $ description ) M
+ AY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.6 NAME 'ipHost' DESC 'Abstraction of a ho
+ st, an IP device' SUP top AUXILIARY MUST ( cn $ ipHostNumber ) MAY ( l $ desc
+ ription $ manager ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' DESC 'Abstraction of a
+ n IP network' SUP top STRUCTURAL MUST ( cn $ ipNetworkNumber ) MAY ( ipNetmas
+ kNumber $ l $ description $ manager ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' DESC 'Abstraction of
+  a netgroup' SUP top STRUCTURAL MUST cn MAY ( nisNetgroupTriple $ memberNisNe
+ tgroup $ description ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.9 NAME 'nisMap' DESC 'A generic abstracti
+ on of a NIS map' SUP top STRUCTURAL MUST nisMapName MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.10 NAME 'nisObject' DESC 'An entry in a 
+ NIS map' SUP top STRUCTURAL MUST ( cn $ nisMapEntry $ nisMapName ) MAY descri
+ ption )
+olcObjectClasses: ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' DESC 'A device w
+ ith a MAC address' SUP top AUXILIARY MAY macAddress )
+olcObjectClasses: ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' DESC 'A device 
+ with boot parameters' SUP top AUXILIARY MAY ( bootFile $ bootParameter ) )

--- a/test/kldap/schema/openldap.ldif
+++ b/test/kldap/schema/openldap.ldif
@@ -1,0 +1,88 @@
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+#
+# OpenLDAP Project's directory schema items
+#
+# depends upon:
+#	core.schema
+#	cosine.schema
+#	inetorgperson.schema
+#
+# These are provided for informational purposes only.
+#
+# This openldap.ldif file is provided as a demonstration of how to
+# convert a *.schema file into *.ldif format. The key points:
+#   In LDIF, a blank line terminates an entry. Blank lines in a *.schema
+#     file should be replaced with a single '#' to turn them into
+#     comments, or they should just be removed.
+#   In addition to the actual schema directives, the file needs a small
+#     header to make it a valid LDAP entry. This header must provide the
+#     dn of the entry, the objectClass, and the cn, as shown here:
+#
+dn: cn=openldap,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: openldap
+#
+# The schema directives need to be changed to LDAP Attributes.
+#   First a basic string substitution can be done on each of the keywords:
+#     objectIdentifier -> olcObjectIdentifier:
+#     objectClass -> olcObjectClasses:
+#     attributeType -> olcAttributeTypes:
+#   Then leading whitespace must be fixed. The slapd.conf format allows
+#     tabs or spaces to denote line continuation, while LDIF only allows
+#     the space character.
+#   Also slapd.conf preserves the continuation character, while LDIF strips
+#     it out. So a single TAB/SPACE in slapd.conf must be replaced with
+#     two SPACEs in LDIF, otherwise the continued text may get joined as
+#     a single word.
+#   The directives must be listed in a proper sequence:
+#     All olcObjectIdentifiers must be first, so they may be referenced by
+#        any following definitions.
+#     All olcAttributeTypes must be next, so they may be referenced by any
+#        following objectClass definitions.
+#     All olcObjectClasses must be after the olcAttributeTypes.
+#   And of course, any superior must occur before anything that inherits
+#     from it.
+#
+olcObjectIdentifier: OpenLDAProot 1.3.6.1.4.1.4203
+#
+olcObjectIdentifier: OpenLDAP OpenLDAProot:1
+olcObjectIdentifier: OpenLDAPattributeType OpenLDAP:3
+olcObjectIdentifier: OpenLDAPobjectClass OpenLDAP:4
+#
+olcObjectClasses: ( OpenLDAPobjectClass:3
+  NAME 'OpenLDAPorg'
+  DESC 'OpenLDAP Organizational Object'
+  SUP organization
+  MAY ( buildingName $ displayName $ labeledURI ) )
+#
+olcObjectClasses: ( OpenLDAPobjectClass:4
+  NAME 'OpenLDAPou'
+  DESC 'OpenLDAP Organizational Unit Object'
+  SUP organizationalUnit
+  MAY ( buildingName $ displayName $ labeledURI $ o ) )
+#
+olcObjectClasses: ( OpenLDAPobjectClass:5
+  NAME 'OpenLDAPperson'
+  DESC 'OpenLDAP Person'
+  SUP ( pilotPerson $ inetOrgPerson )
+  MUST ( uid $ cn )
+  MAY ( givenName $ labeledURI $ o ) )
+#
+olcObjectClasses: ( OpenLDAPobjectClass:6
+  NAME 'OpenLDAPdisplayableObject'
+  DESC 'OpenLDAP Displayable Object'
+  AUXILIARY
+  MAY displayName )

--- a/test/kldap/schema/pmi.ldif
+++ b/test/kldap/schema/pmi.ldif
@@ -1,0 +1,123 @@
+# OpenLDAP X.509 PMI schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (1997-2006).
+## All Rights Reserved.
+#
+# Includes LDAPv3 schema items from:
+# ITU X.509 (08/2005)
+#
+# This file was automatically generated from pmi.schema; see that file
+# for complete references.
+#
+dn: cn=pmi,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: pmi
+olcObjectIdentifier: {0}id-oc-pmiUser 2.5.6.24
+olcObjectIdentifier: {1}id-oc-pmiAA 2.5.6.25
+olcObjectIdentifier: {2}id-oc-pmiSOA 2.5.6.26
+olcObjectIdentifier: {3}id-oc-attCertCRLDistributionPts 2.5.6.27
+olcObjectIdentifier: {4}id-oc-privilegePolicy 2.5.6.32
+olcObjectIdentifier: {5}id-oc-pmiDelegationPath 2.5.6.33
+olcObjectIdentifier: {6}id-oc-protectedPrivilegePolicy 2.5.6.34
+olcObjectIdentifier: {7}id-at-attributeCertificate 2.5.4.58
+olcObjectIdentifier: {8}id-at-attributeCertificateRevocationList 2.5.4.59
+olcObjectIdentifier: {9}id-at-aACertificate 2.5.4.61
+olcObjectIdentifier: {10}id-at-attributeDescriptorCertificate 2.5.4.62
+olcObjectIdentifier: {11}id-at-attributeAuthorityRevocationList 2.5.4.63
+olcObjectIdentifier: {12}id-at-privPolicy 2.5.4.71
+olcObjectIdentifier: {13}id-at-role 2.5.4.72
+olcObjectIdentifier: {14}id-at-delegationPath 2.5.4.73
+olcObjectIdentifier: {15}id-at-protPrivPolicy 2.5.4.74
+olcObjectIdentifier: {16}id-at-xMLPrivilegeInfo 2.5.4.75
+olcObjectIdentifier: {17}id-at-xMLPprotPrivPolicy 2.5.4.76
+olcObjectIdentifier: {18}id-mr 2.5.13
+olcObjectIdentifier: {19}id-mr-attributeCertificateMatch id-mr:42
+olcObjectIdentifier: {20}id-mr-attributeCertificateExactMatch id-mr:45
+olcObjectIdentifier: {21}id-mr-holderIssuerMatch id-mr:46
+olcObjectIdentifier: {22}id-mr-authAttIdMatch id-mr:53
+olcObjectIdentifier: {23}id-mr-roleSpecCertIdMatch id-mr:54
+olcObjectIdentifier: {24}id-mr-basicAttConstraintsMatch id-mr:55
+olcObjectIdentifier: {25}id-mr-delegatedNameConstraintsMatch id-mr:56
+olcObjectIdentifier: {26}id-mr-timeSpecMatch id-mr:57
+olcObjectIdentifier: {27}id-mr-attDescriptorMatch id-mr:58
+olcObjectIdentifier: {28}id-mr-acceptableCertPoliciesMatch id-mr:59
+olcObjectIdentifier: {29}id-mr-delegationPathMatch id-mr:61
+olcObjectIdentifier: {30}id-mr-sOAIdentifierMatch id-mr:66
+olcObjectIdentifier: {31}id-mr-indirectIssuerMatch id-mr:67
+olcObjectIdentifier: {32}AttributeCertificate 1.3.6.1.4.1.4203.666.11.10.2.1
+olcObjectIdentifier: {33}CertificateList 1.3.6.1.4.1.1466.115.121.1.9
+olcObjectIdentifier: {34}AttCertPath 1.3.6.1.4.1.4203.666.11.10.2.4
+olcObjectIdentifier: {35}PolicySyntax 1.3.6.1.4.1.4203.666.11.10.2.5
+olcObjectIdentifier: {36}RoleSyntax 1.3.6.1.4.1.4203.666.11.10.2.6
+olcLdapSyntaxes: {0}( 1.3.6.1.4.1.4203.666.11.10.2.4 DESC 'X.509 PMI attribute
+  cartificate path: SEQUENCE OF AttributeCertificate' X-SUBST '1.3.6.1.4.1.146
+ 6.115.121.1.15' )
+olcLdapSyntaxes: {1}( 1.3.6.1.4.1.4203.666.11.10.2.5 DESC 'X.509 PMI policy sy
+ ntax' X-SUBST '1.3.6.1.4.1.1466.115.121.1.15' )
+olcLdapSyntaxes: {2}( 1.3.6.1.4.1.4203.666.11.10.2.6 DESC 'X.509 PMI role synt
+ ax' X-SUBST '1.3.6.1.4.1.1466.115.121.1.15' )
+olcAttributeTypes: {0}( id-at-role NAME 'role' DESC 'X.509 Role attribute, use
+  ;binary' SYNTAX RoleSyntax )
+olcAttributeTypes: {1}( id-at-xMLPrivilegeInfo NAME 'xmlPrivilegeInfo' DESC 'X
+ .509 XML privilege information attribute' SYNTAX 1.3.6.1.4.1.1466.115.121.1.1
+ 5 )
+olcAttributeTypes: {2}( id-at-attributeCertificate NAME 'attributeCertificateA
+ ttribute' DESC 'X.509 Attribute certificate attribute, use ;binary' EQUALITY 
+ attributeCertificateExactMatch SYNTAX AttributeCertificate )
+olcAttributeTypes: {3}( id-at-aACertificate NAME 'aACertificate' DESC 'X.509 A
+ A certificate attribute, use ;binary' EQUALITY attributeCertificateExactMatch
+  SYNTAX AttributeCertificate )
+olcAttributeTypes: {4}( id-at-attributeDescriptorCertificate NAME 'attributeDe
+ scriptorCertificate' DESC 'X.509 Attribute descriptor certificate attribute, 
+ use ;binary' EQUALITY attributeCertificateExactMatch SYNTAX AttributeCertific
+ ate )
+olcAttributeTypes: {5}( id-at-attributeCertificateRevocationList NAME 'attribu
+ teCertificateRevocationList' DESC 'X.509 Attribute certificate revocation lis
+ t attribute, use ;binary' SYNTAX CertificateList X-EQUALITY 'certificateListE
+ xactMatch, not implemented yet' )
+olcAttributeTypes: {6}( id-at-attributeAuthorityRevocationList NAME 'attribute
+ AuthorityRevocationList' DESC 'X.509 AA certificate revocation list attribute
+ , use ;binary' SYNTAX CertificateList X-EQUALITY 'certificateListExactMatch, 
+ not implemented yet' )
+olcAttributeTypes: {7}( id-at-delegationPath NAME 'delegationPath' DESC 'X.509
+  Delegation path attribute, use ;binary' SYNTAX AttCertPath )
+olcAttributeTypes: {8}( id-at-privPolicy NAME 'privPolicy' DESC 'X.509 Privile
+ ge policy attribute, use ;binary' SYNTAX PolicySyntax )
+olcAttributeTypes: {9}( id-at-protPrivPolicy NAME 'protPrivPolicy' DESC 'X.509
+  Protected privilege policy attribute, use ;binary' EQUALITY attributeCertifi
+ cateExactMatch SYNTAX AttributeCertificate )
+olcAttributeTypes: {10}( id-at-xMLPprotPrivPolicy NAME 'xmlPrivPolicy' DESC 'X
+ .509 XML Protected privilege policy attribute' SYNTAX 1.3.6.1.4.1.1466.115.12
+ 1.1.15 )
+olcObjectClasses: {0}( id-oc-pmiUser NAME 'pmiUser' DESC 'X.509 PMI user objec
+ t class' SUP top AUXILIARY MAY attributeCertificateAttribute )
+olcObjectClasses: {1}( id-oc-pmiAA NAME 'pmiAA' DESC 'X.509 PMI AA object clas
+ s' SUP top AUXILIARY MAY ( aACertificate $ attributeCertificateRevocationList
+  $ attributeAuthorityRevocationList ) )
+olcObjectClasses: {2}( id-oc-pmiSOA NAME 'pmiSOA' DESC 'X.509 PMI SOA object c
+ lass' SUP top AUXILIARY MAY ( attributeCertificateRevocationList $ attributeA
+ uthorityRevocationList $ attributeDescriptorCertificate ) )
+olcObjectClasses: {3}( id-oc-attCertCRLDistributionPts NAME 'attCertCRLDistrib
+ utionPt' DESC 'X.509 Attribute certificate CRL distribution point object clas
+ s' SUP top AUXILIARY MAY ( attributeCertificateRevocationList $ attributeAuth
+ orityRevocationList ) )
+olcObjectClasses: {4}( id-oc-pmiDelegationPath NAME 'pmiDelegationPath' DESC '
+ X.509 PMI delegation path' SUP top AUXILIARY MAY delegationPath )
+olcObjectClasses: {5}( id-oc-privilegePolicy NAME 'privilegePolicy' DESC 'X.50
+ 9 Privilege policy object class' SUP top AUXILIARY MAY privPolicy )
+olcObjectClasses: {6}( id-oc-protectedPrivilegePolicy NAME 'protectedPrivilege
+ Policy' DESC 'X.509 Protected privilege policy object class' SUP top AUXILIAR
+ Y MAY protPrivPolicy )

--- a/test/kldap/schema/ppolicy.ldif
+++ b/test/kldap/schema/ppolicy.ldif
@@ -1,0 +1,75 @@
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 2004-2012 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (2004).
+## Please see full copyright statement below.
+#
+# Definitions from Draft behera-ldap-password-policy-07 (a work in progress)
+#	Password Policy for LDAP Directories
+# With extensions from Hewlett-Packard:
+#	pwdCheckModule etc.
+#
+# Contents of this file are subject to change (including deletion)
+# without notice.
+#
+# Not recommended for production use!
+# Use with extreme caution!
+#
+# This file was automatically generated from ppolicy.schema; see that file
+# for complete references.
+#
+dn: cn=ppolicy,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: ppolicy
+olcAttributeTypes: {0}( 1.3.6.1.4.1.42.2.27.8.1.1 NAME 'pwdAttribute' EQUALITY
+  objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 )
+olcAttributeTypes: {1}( 1.3.6.1.4.1.42.2.27.8.1.2 NAME 'pwdMinAge' EQUALITY in
+ tegerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {2}( 1.3.6.1.4.1.42.2.27.8.1.3 NAME 'pwdMaxAge' EQUALITY in
+ tegerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {3}( 1.3.6.1.4.1.42.2.27.8.1.4 NAME 'pwdInHistory' EQUALITY
+  integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {4}( 1.3.6.1.4.1.42.2.27.8.1.5 NAME 'pwdCheckQuality' EQUAL
+ ITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {5}( 1.3.6.1.4.1.42.2.27.8.1.6 NAME 'pwdMinLength' EQUALITY
+  integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {6}( 1.3.6.1.4.1.42.2.27.8.1.7 NAME 'pwdExpireWarning' EQUA
+ LITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {7}( 1.3.6.1.4.1.42.2.27.8.1.8 NAME 'pwdGraceAuthNLimit' EQ
+ UALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {8}( 1.3.6.1.4.1.42.2.27.8.1.9 NAME 'pwdLockout' EQUALITY b
+ ooleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE )
+olcAttributeTypes: {9}( 1.3.6.1.4.1.42.2.27.8.1.10 NAME 'pwdLockoutDuration' E
+ QUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {10}( 1.3.6.1.4.1.42.2.27.8.1.11 NAME 'pwdMaxFailure' EQUAL
+ ITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {11}( 1.3.6.1.4.1.42.2.27.8.1.12 NAME 'pwdFailureCountInter
+ val' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE 
+ )
+olcAttributeTypes: {12}( 1.3.6.1.4.1.42.2.27.8.1.13 NAME 'pwdMustChange' EQUAL
+ ITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE )
+olcAttributeTypes: {13}( 1.3.6.1.4.1.42.2.27.8.1.14 NAME 'pwdAllowUserChange' 
+ EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE )
+olcAttributeTypes: {14}( 1.3.6.1.4.1.42.2.27.8.1.15 NAME 'pwdSafeModify' EQUAL
+ ITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE )
+olcAttributeTypes: {15}( 1.3.6.1.4.1.4754.1.99.1 NAME 'pwdCheckModule' DESC 'L
+ oadable module that instantiates "check_password() function' EQUALITY caseExa
+ ctIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+olcObjectClasses: {0}( 1.3.6.1.4.1.4754.2.99.1 NAME 'pwdPolicyChecker' SUP top
+  AUXILIARY MAY pwdCheckModule )
+olcObjectClasses: {1}( 1.3.6.1.4.1.42.2.27.8.2.1 NAME 'pwdPolicy' SUP top AUXI
+ LIARY MUST pwdAttribute MAY ( pwdMinAge $ pwdMaxAge $ pwdInHistory $ pwdCheck
+ Quality $ pwdMinLength $ pwdExpireWarning $ pwdGraceAuthNLimit $ pwdLockout $
+  pwdLockoutDuration $ pwdMaxFailure $ pwdFailureCountInterval $ pwdMustChange
+  $ pwdAllowUserChange $ pwdSafeModify ) )

--- a/test/kldap/schema/samba.ldif
+++ b/test/kldap/schema/samba.ldif
@@ -1,0 +1,187 @@
+# samba, schema, config
+dn: cn=samba,cn=schema,cn=config
+changetype: add
+objectClass: olcSchemaConfig
+cn: samba
+olcAttributeTypes: {0}( 1.3.6.1.4.1.7165.2.1.24 NAME 'sambaLMPassword' DESC 'L
+ anManager Password' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.1
+ 21.1.26{32} SINGLE-VALUE )
+olcAttributeTypes: {1}( 1.3.6.1.4.1.7165.2.1.25 NAME 'sambaNTPassword' DESC 'M
+ D4 hash of the unicode password' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4
+ .1.1466.115.121.1.26{32} SINGLE-VALUE )
+olcAttributeTypes: {2}( 1.3.6.1.4.1.7165.2.1.26 NAME 'sambaAcctFlags' DESC 'Ac
+ count Flags' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+ {16} SINGLE-VALUE )
+olcAttributeTypes: {3}( 1.3.6.1.4.1.7165.2.1.27 NAME 'sambaPwdLastSet' DESC 'T
+ imestamp of the last password update' EQUALITY integerMatch SYNTAX 1.3.6.1.4.
+ 1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {4}( 1.3.6.1.4.1.7165.2.1.28 NAME 'sambaPwdCanChange' DESC 
+ 'Timestamp of when the user is allowed to update the password' EQUALITY integ
+ erMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {5}( 1.3.6.1.4.1.7165.2.1.29 NAME 'sambaPwdMustChange' DESC
+  'Timestamp of when the password will expire' EQUALITY integerMatch SYNTAX 1.
+ 3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {6}( 1.3.6.1.4.1.7165.2.1.30 NAME 'sambaLogonTime' DESC 'Ti
+ mestamp of last logon' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.
+ 1.27 SINGLE-VALUE )
+olcAttributeTypes: {7}( 1.3.6.1.4.1.7165.2.1.31 NAME 'sambaLogoffTime' DESC 'T
+ imestamp of last logoff' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.12
+ 1.1.27 SINGLE-VALUE )
+olcAttributeTypes: {8}( 1.3.6.1.4.1.7165.2.1.32 NAME 'sambaKickoffTime' DESC '
+ Timestamp of when the user will be logged off automatically' EQUALITY integer
+ Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {9}( 1.3.6.1.4.1.7165.2.1.48 NAME 'sambaBadPasswordCount' D
+ ESC 'Bad password attempt count' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.146
+ 6.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {10}( 1.3.6.1.4.1.7165.2.1.49 NAME 'sambaBadPasswordTime' D
+ ESC 'Time of the last bad password attempt' EQUALITY integerMatch SYNTAX 1.3.
+ 6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {11}( 1.3.6.1.4.1.7165.2.1.55 NAME 'sambaLogonHours' DESC '
+ Logon Hours' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+ {42} SINGLE-VALUE )
+olcAttributeTypes: {12}( 1.3.6.1.4.1.7165.2.1.33 NAME 'sambaHomeDrive' DESC 'D
+ river letter of home directory mapping' EQUALITY caseIgnoreIA5Match SYNTAX 1.
+ 3.6.1.4.1.1466.115.121.1.26{4} SINGLE-VALUE )
+olcAttributeTypes: {13}( 1.3.6.1.4.1.7165.2.1.34 NAME 'sambaLogonScript' DESC 
+ 'Logon script path' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.
+ 1.15{255} SINGLE-VALUE )
+olcAttributeTypes: {14}( 1.3.6.1.4.1.7165.2.1.35 NAME 'sambaProfilePath' DESC 
+ 'Roaming profile path' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.1
+ 21.1.15{255} SINGLE-VALUE )
+olcAttributeTypes: {15}( 1.3.6.1.4.1.7165.2.1.36 NAME 'sambaUserWorkstations' 
+ DESC 'List of user workstations the user is allowed to logon to' EQUALITY cas
+ eIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{255} SINGLE-VALUE )
+olcAttributeTypes: {16}( 1.3.6.1.4.1.7165.2.1.37 NAME 'sambaHomePath' DESC 'Ho
+ me directory UNC path' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.1
+ 21.1.15{128} )
+olcAttributeTypes: {17}( 1.3.6.1.4.1.7165.2.1.38 NAME 'sambaDomainName' DESC '
+ Windows NT domain to which the user belongs' EQUALITY caseIgnoreMatch SYNTAX 
+ 1.3.6.1.4.1.1466.115.121.1.15{128} )
+olcAttributeTypes: {18}( 1.3.6.1.4.1.7165.2.1.47 NAME 'sambaMungedDial' DESC '
+ Base64 encoded user parameter string' EQUALITY caseExactMatch SYNTAX 1.3.6.1.
+ 4.1.1466.115.121.1.15{1050} )
+olcAttributeTypes: {19}( 1.3.6.1.4.1.7165.2.1.54 NAME 'sambaPasswordHistory' D
+ ESC 'Concatenated MD5 hashes of the salted NT passwords used on this account'
+  EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{32} )
+olcAttributeTypes: {20}( 1.3.6.1.4.1.7165.2.1.20 NAME 'sambaSID' DESC 'Securit
+ y ID' EQUALITY caseIgnoreIA5Match SUBSTR caseExactIA5SubstringsMatch SYNTAX 1
+ .3.6.1.4.1.1466.115.121.1.26{64} SINGLE-VALUE )
+olcAttributeTypes: {21}( 1.3.6.1.4.1.7165.2.1.23 NAME 'sambaPrimaryGroupSID' D
+ ESC 'Primary Group Security ID' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.
+ 1.1466.115.121.1.26{64} SINGLE-VALUE )
+olcAttributeTypes: {22}( 1.3.6.1.4.1.7165.2.1.51 NAME 'sambaSIDList' DESC 'Sec
+ urity ID List' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.
+ 26{64} )
+olcAttributeTypes: {23}( 1.3.6.1.4.1.7165.2.1.19 NAME 'sambaGroupType' DESC 'N
+ T Group Type' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SING
+ LE-VALUE )
+olcAttributeTypes: {24}( 1.3.6.1.4.1.7165.2.1.21 NAME 'sambaNextUserRid' DESC 
+ 'Next NT rid to give our for users' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.
+ 1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {25}( 1.3.6.1.4.1.7165.2.1.22 NAME 'sambaNextGroupRid' DESC
+  'Next NT rid to give out for groups' EQUALITY integerMatch SYNTAX 1.3.6.1.4.
+ 1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {26}( 1.3.6.1.4.1.7165.2.1.39 NAME 'sambaNextRid' DESC 'Nex
+ t NT rid to give out for anything' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1
+ 466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {27}( 1.3.6.1.4.1.7165.2.1.40 NAME 'sambaAlgorithmicRidBase
+ ' DESC 'Base at which the samba RID generation algorithm should operate' EQUA
+ LITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {28}( 1.3.6.1.4.1.7165.2.1.41 NAME 'sambaShareName' DESC 'S
+ hare Name' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SING
+ LE-VALUE )
+olcAttributeTypes: {29}( 1.3.6.1.4.1.7165.2.1.42 NAME 'sambaOptionName' DESC '
+ Option Name' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.15{256} )
+olcAttributeTypes: {30}( 1.3.6.1.4.1.7165.2.1.43 NAME 'sambaBoolOption' DESC '
+ A boolean option' EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 S
+ INGLE-VALUE )
+olcAttributeTypes: {31}( 1.3.6.1.4.1.7165.2.1.44 NAME 'sambaIntegerOption' DES
+ C 'An integer option' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1
+ .27 SINGLE-VALUE )
+olcAttributeTypes: {32}( 1.3.6.1.4.1.7165.2.1.45 NAME 'sambaStringOption' DESC
+  'A string option' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121
+ .1.26 SINGLE-VALUE )
+olcAttributeTypes: {33}( 1.3.6.1.4.1.7165.2.1.46 NAME 'sambaStringListOption' 
+ DESC 'A string list option' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.
+ 115.121.1.15 )
+olcAttributeTypes: {34}( 1.3.6.1.4.1.7165.2.1.53 NAME 'sambaTrustFlags' DESC '
+ Trust Password Flags' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115
+ .121.1.26 )
+olcAttributeTypes: {35}( 1.3.6.1.4.1.7165.2.1.58 NAME 'sambaMinPwdLength' DESC
+  'Minimal password length (default: 5)' EQUALITY integerMatch SYNTAX 1.3.6.1.
+ 4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {36}( 1.3.6.1.4.1.7165.2.1.59 NAME 'sambaPwdHistoryLength' 
+ DESC 'Length of Password History Entries (default: 0 => off)' EQUALITY intege
+ rMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {37}( 1.3.6.1.4.1.7165.2.1.60 NAME 'sambaLogonToChgPwd' DES
+ C 'Force Users to logon for password change (default: 0 => off, 2 => on)' EQU
+ ALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {38}( 1.3.6.1.4.1.7165.2.1.61 NAME 'sambaMaxPwdAge' DESC 'M
+ aximum password age, in seconds (default: -1 => never expire passwords)' EQUA
+ LITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {39}( 1.3.6.1.4.1.7165.2.1.62 NAME 'sambaMinPwdAge' DESC 'M
+ inimum password age, in seconds (default: 0 => allow immediate password chang
+ e)' EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {40}( 1.3.6.1.4.1.7165.2.1.63 NAME 'sambaLockoutDuration' D
+ ESC 'Lockout duration in minutes (default: 30, -1 => forever)' EQUALITY integ
+ erMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {41}( 1.3.6.1.4.1.7165.2.1.64 NAME 'sambaLockoutObservation
+ Window' DESC 'Reset time after lockout in minutes (default: 30)' EQUALITY int
+ egerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {42}( 1.3.6.1.4.1.7165.2.1.65 NAME 'sambaLockoutThreshold' 
+ DESC 'Lockout users after bad logon attempts (default: 0 => off)' EQUALITY in
+ tegerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {43}( 1.3.6.1.4.1.7165.2.1.66 NAME 'sambaForceLogoff' DESC 
+ 'Disconnect Users outside logon hours (default: -1 => off, 0 => on)' EQUALITY
+  integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {44}( 1.3.6.1.4.1.7165.2.1.67 NAME 'sambaRefuseMachinePwdCh
+ ange' DESC 'Allow Machine Password changes (default: 0 => off)' EQUALITY inte
+ gerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {45}( 1.3.6.1.4.1.7165.2.1.68 NAME 'sambaClearTextPassword'
+  DESC 'Clear text password (used for trusted domain passwords)' EQUALITY octe
+ tStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+olcAttributeTypes: {46}( 1.3.6.1.4.1.7165.2.1.69 NAME 'sambaPreviousClearTextP
+ assword' DESC 'Previous clear text password (used for trusted domain password
+ s)' EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+olcObjectClasses: {0}( 1.3.6.1.4.1.7165.2.2.6 NAME 'sambaSamAccount' DESC 'Sam
+ ba 3.0 Auxilary SAM Account' SUP top AUXILIARY MUST ( uid $ sambaSID ) MAY ( 
+ cn $ sambaLMPassword $ sambaNTPassword $ sambaPwdLastSet $ sambaLogonTime $ s
+ ambaLogoffTime $ sambaKickoffTime $ sambaPwdCanChange $ sambaPwdMustChange $ 
+ sambaAcctFlags $ displayName $ sambaHomePath $ sambaHomeDrive $ sambaLogonScr
+ ipt $ sambaProfilePath $ description $ sambaUserWorkstations $ sambaPrimaryGr
+ oupSID $ sambaDomainName $ sambaMungedDial $ sambaBadPasswordCount $ sambaBad
+ PasswordTime $ sambaPasswordHistory $ sambaLogonHours ) )
+olcObjectClasses: {1}( 1.3.6.1.4.1.7165.2.2.4 NAME 'sambaGroupMapping' DESC 'S
+ amba Group Mapping' SUP top AUXILIARY MUST ( gidNumber $ sambaSID $ sambaGrou
+ pType ) MAY ( displayName $ description $ sambaSIDList ) )
+olcObjectClasses: {2}( 1.3.6.1.4.1.7165.2.2.14 NAME 'sambaTrustPassword' DESC 
+ 'Samba Trust Password' SUP top STRUCTURAL MUST ( sambaDomainName $ sambaNTPas
+ sword $ sambaTrustFlags ) MAY ( sambaSID $ sambaPwdLastSet ) )
+olcObjectClasses: {3}( 1.3.6.1.4.1.7165.2.2.15 NAME 'sambaTrustedDomainPasswor
+ d' DESC 'Samba Trusted Domain Password' SUP top STRUCTURAL MUST ( sambaDomain
+ Name $ sambaSID $ sambaClearTextPassword $ sambaPwdLastSet ) MAY sambaPreviou
+ sClearTextPassword )
+olcObjectClasses: {4}( 1.3.6.1.4.1.7165.2.2.5 NAME 'sambaDomain' DESC 'Samba D
+ omain Information' SUP top STRUCTURAL MUST ( sambaDomainName $ sambaSID ) MAY
+  ( sambaNextRid $ sambaNextGroupRid $ sambaNextUserRid $ sambaAlgorithmicRidB
+ ase $ sambaMinPwdLength $ sambaPwdHistoryLength $ sambaLogonToChgPwd $ sambaM
+ axPwdAge $ sambaMinPwdAge $ sambaLockoutDuration $ sambaLockoutObservationWin
+ dow $ sambaLockoutThreshold $ sambaForceLogoff $ sambaRefuseMachinePwdChange 
+ ) )
+olcObjectClasses: {5}( 1.3.6.1.4.1.7165.2.2.7 NAME 'sambaUnixIdPool' DESC 'Poo
+ l for allocating UNIX uids/gids' SUP top AUXILIARY MUST ( uidNumber $ gidNumb
+ er ) )
+olcObjectClasses: {6}( 1.3.6.1.4.1.7165.2.2.8 NAME 'sambaIdmapEntry' DESC 'Map
+ ping from a SID to an ID' SUP top AUXILIARY MUST sambaSID MAY ( uidNumber $ g
+ idNumber ) )
+olcObjectClasses: {7}( 1.3.6.1.4.1.7165.2.2.9 NAME 'sambaSidEntry' DESC 'Struc
+ tural Class for a SID' SUP top STRUCTURAL MUST sambaSID )
+olcObjectClasses: {8}( 1.3.6.1.4.1.7165.2.2.10 NAME 'sambaConfig' DESC 'Samba 
+ Configuration Section' SUP top AUXILIARY MAY description )
+olcObjectClasses: {9}( 1.3.6.1.4.1.7165.2.2.11 NAME 'sambaShare' DESC 'Samba S
+ hare Section' SUP top STRUCTURAL MUST sambaShareName MAY description )
+olcObjectClasses: {10}( 1.3.6.1.4.1.7165.2.2.12 NAME 'sambaConfigOption' DESC 
+ 'Samba Configuration Option' SUP top STRUCTURAL MUST sambaOptionName MAY ( sa
+ mbaBoolOption $ sambaIntegerOption $ sambaStringOption $ sambaStringListoptio
+ n $ description ) )

--- a/test/kldap/schemas.bash
+++ b/test/kldap/schemas.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "loading schema files..."
+
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/core.ldif
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/cosine.ldif
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/inetorgperson.ldif
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/nis.ldif
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/eduorg.ldif
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/eduperson.ldif
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/kerberos.ldif
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/misc.ldif
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./schema/samba.ldif
+

--- a/test/kldap/setup.bash
+++ b/test/kldap/setup.bash
@@ -1,0 +1,96 @@
+
+
+function mkpasswd {
+    python -c "import string, random; print ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in xrange(32))"
+}
+
+# generate passwords 
+MASTER_PASSWORD=`mkpasswd`
+CONFIG_ROOT=`mkpasswd`
+MDB_ROOT=`mkpasswd`
+
+KRB5KDC_PASSWORD=`mkpasswd`
+KADMIND_PASSWORD=`mkpasswd`
+
+kdb5_ldap_util destroy -f
+
+# load an updated krb5.conf with correct permissions
+chown --reference=/etc/krb5.conf ./krb5.conf 
+chmod --reference=/etc/krb5.conf ./krb5.conf 
+cp ./krb5.conf /etc/krb5.conf
+restorecon /etc/krb5.conf
+
+chown --reference=/etc/openldap/ldap.conf ./ldap.conf 
+chmod --reference=/etc/openldap/ldap.conf ./ldap.conf 
+cp ./ldap.conf /etc/openldap/ldap.conf
+restorecon /etc/openldap/ldap.conf
+
+# setup database directory
+mkdir -p /srv/ldap/example.com/
+
+# make sure selinux is alright with our directory serving ldap data
+semanage fcontext -ae /var/lib/ldap /srv/ldap/example.com
+restorecon -Rv /srv/ldap
+
+# halt any existing slapd server
+service slapd stop
+killall slapd
+
+# purge old configurations and data
+rm -rf /etc/openldap/slapd.d/*
+rm -rf /srv/ldap/example.com/*
+
+# load cn=config database
+slapadd -n0 -F /etc/openldap/slapd.d/ -l ./cn_config.ldif
+
+cat ./olcDatabase_0.ldif | sed -e "s#CONFIG_ROOT#$CONFIG_ROOT#g" > /tmp/olcDatabase_0.ldif
+
+slapadd -n0 -F /etc/openldap/slapd.d/ -l /tmp/olcDatabase_0.ldif
+
+# restore permissions before starting server
+chown -R ldap:ldap /etc/openldap
+chown -R ldap:ldap /srv/ldap/example.com
+
+# start server
+service slapd start
+
+# add modules
+ldapmodify -D "cn=config" -H ldapi:/// -x -w "$CONFIG_ROOT" -a -f ./cn_module.ldif
+
+# add schemas (kerberos.ldif is added here)
+bash ./schemas.bash
+
+# configure a database (mdb) for use to store data
+cat ./olcDatabase_mdb.ldif | sed -e "s#MDB_ROOT#$MDB_ROOT#g" > /tmp/olcDatabase_mdb.ldif
+
+ldapmodify -D "cn=config" -H ldapi:/// -x -w "$CONFIG_ROOT" -a -f /tmp/olcDatabase_mdb.ldif
+
+# create our dit including the accounts for kerberos and test accounts for db_args 
+ldapmodify -Q -H ldapi:/// -Y EXTERNAL -ac -f ./dit.ldif
+
+# set the password so it hashes properly
+ldappasswd -Q -s $KADMIND_PASSWORD uid=kadmin,ou=accounts,dc=example,dc=com
+ldappasswd -Q -s $KRB5KDC_PASSWORD uid=krb5kdc,ou=accounts,dc=example,dc=com
+
+# init kerberos realm inside the ldap database
+cat ./kdb_create.expect | sed -e "s#MASTER_PASSWORD#$MASTER_PASSWORD#g" | sed -e "s#MDB_ROOT#$MDB_ROOT#g" > /tmp/kdb_create.expect
+expect /tmp/kdb_create.expect
+
+cat ./stash_kadmind.expect | sed -e "s#MDB_ROOT#$MDB_ROOT#g" | sed -e "s#KADMIND_PASSWORD#$KADMIND_PASSWORD#g" > /tmp/stash_kadmind.expect
+expect /tmp/stash_kadmind.expect
+
+cat ./stash_krb5kdc.expect | sed -e "s#MDB_ROOT#$MDB_ROOT#g" | sed -e "s#KRB5KDC_PASSWORD#$KRB5KDC_PASSWORD#g" > /tmp/stash_krb5kdc.expect
+expect /tmp/stash_krb5kdc.expect
+
+
+# create default accounts
+kadmin.local -q "ank -randkey kadmin/admin"
+kadmin.local -q "ank -randkey kadmin/changepw"
+
+# restart kadmin and krb5kdc 
+service kadmin restart
+service krb5kdc restart
+
+
+
+

--- a/test/kldap/stash_kadmind.expect
+++ b/test/kldap/stash_kadmind.expect
@@ -1,0 +1,15 @@
+#!/usr/bin/expect
+
+set timeout -1
+spawn $env(SHELL)
+match_max 100000
+send -- "/usr/sbin/kdb5_ldap_util -D cn=root,dc=example,dc=com -w MDB_ROOT -H ldapi:/// stashsrvpw -f /var/kerberos/krb5kdc/.ldap.EXAMPLE.COM uid=kadmin,ou=accounts,dc=example,dc=com"
+expect -exact "/usr/sbin/kdb5_ldap_util -D cn=root,dc=example,dc=com -w MDB_ROOT -H ldapi:/// stashsrvpw -f /var/kerberos/krb5kdc/.ldap.EXAMPLE.COM uid=kadmin,ou=accounts,dc=example,dc=com"
+send -- "\r"
+expect "Password for \"uid=kadmin,ou=accounts,dc=example,dc=com\": "
+send -- "KADMIND_PASSWORD\r"
+expect "Re-enter password for \"uid=kadmin,ou=accounts,dc=example,dc=com\": "
+send -- "KADMIND_PASSWORD\r"
+expect "\r"
+send -- "exit\r"
+expect eof

--- a/test/kldap/stash_krb5kdc.expect
+++ b/test/kldap/stash_krb5kdc.expect
@@ -1,0 +1,15 @@
+#!/usr/bin/expect
+
+set timeout -1
+spawn $env(SHELL)
+match_max 100000
+send -- "/usr/sbin/kdb5_ldap_util -D cn=root,dc=example,dc=com -w MDB_ROOT -H ldapi:/// stashsrvpw -f /var/kerberos/krb5kdc/.ldap.EXAMPLE.COM uid=krb5kdc,ou=accounts,dc=example,dc=com"
+expect -exact "/usr/sbin/kdb5_ldap_util -D cn=root,dc=example,dc=com -w MDB_ROOT -H ldapi:/// stashsrvpw -f /var/kerberos/krb5kdc/.ldap.EXAMPLE.COM uid=krb5kdc,ou=accounts,dc=example,dc=com"
+send -- "\r"
+expect "Password for \"uid=krb5kdc,ou=accounts,dc=example,dc=com\": "
+send -- "KRB5KDC_PASSWORD\r"
+expect "Re-enter password for \"uid=krb5kdc,ou=accounts,dc=example,dc=com\": "
+send -- "KRB5KDC_PASSWORD\r"
+expect "\r"
+send -- "exit\r"
+expect eof

--- a/test/stock/kdb_create.expect
+++ b/test/stock/kdb_create.expect
@@ -1,0 +1,15 @@
+#!/usr/bin/expect
+
+set timeout -1
+spawn $env(SHELL)
+match_max 100000
+send -- "/usr/sbin/kdb5_util create -s"
+expect -exact "/usr/sbin/kdb5_util create -s"
+send -- "\r"
+expect "Enter KDC database master key: "
+send -- "MASTER_PASSWORD\r"
+expect "Re-enter KDC database master key to verify: "
+send -- "MASTER_PASSWORD\r"
+expect "\r"
+send -- "exit\r"
+expect eof

--- a/test/stock/krb5.conf
+++ b/test/stock/krb5.conf
@@ -1,0 +1,22 @@
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ default_realm = EXAMPLE.COM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h 
+ renew_lifetime = 7d
+ forwardable = true
+
+[realms]
+ EXAMPLE.COM = { 
+  kdc = kerberos.example.com
+  admin_server = kerberos.example.com
+ }
+
+[domain_realm]
+ .example.com = EXAMPLE.COM
+ example.com = EXAMPLE.COM

--- a/test/stock/setup.bash
+++ b/test/stock/setup.bash
@@ -1,0 +1,24 @@
+
+function mkpasswd {
+    python -c "import string, random; print ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in xrange(32))"
+}
+
+kdb5_util destroy -f
+
+# load an updated krb5.conf with correct permissions
+chown --reference=/etc/krb5.conf ./krb5.conf 
+chmod --reference=/etc/krb5.conf ./krb5.conf 
+cp ./krb5.conf /etc/krb5.conf
+restorecon /etc/krb5.conf
+
+MASTER_PASSWORD=`mkpasswd`
+
+cat ./kdb_create.expect | sed -e "s#MASTER_PASSWORD#$MASTER_PASSWORD#g" > /tmp/kdb_create.expect
+
+expect /tmp/kdb_create.expect
+
+kadmin.local -q "ank -randkey kadmin/admin"
+kadmin.local -q "ank -randkey kadmin/changepw"
+
+service kadmin restart
+service krb5kdc restart


### PR DESCRIPTION
...d/del princ methods

changes for db_args

changes which permit principal creation to accept db_args

test/stock and test/kldap; setup.bash will provision a new database for testing stock kerberos or kldap database interactions - all passwords randomize during setup.

kadmin.c - dont force dict type for db_args