### PR TITLE
Make getprinc raise an exception on insufficient privileges

### DIFF
--- a/src/PyKAdminPrincipalObject.c
+++ b/src/PyKAdminPrincipalObject.c
@@ -1013,6 +1013,8 @@ PyKAdminPrincipalObject *PyKAdminPrincipalObject_principal_with_name(PyKAdminObj
 
             if ((retval != KADM5_OK) || code) {
                 PyKAdminPrincipal_dealloc(principal);
+                if (retval == KADM5_AUTH_GET)
+                    PyKAdminError_raise_error(retval, "kadm5_get_principal");
                 principal = (PyKAdminPrincipalObject *)Py_None;
             }
 


### PR DESCRIPTION
Previously, getprinc would silently failed if permissions were missing. With this change, such errors can nicely be detected by the user using code such as:

try:
  return kadm.getprinc(princ)
except kadmin.AuthGetError:
  ...