### PR TITLE
Prevent NULL pointer dereference if kadm5_init_with_creds fails

### DIFF
--- a/src/kadmin.c
+++ b/src/kadmin.c
@@ -309,14 +309,6 @@ static PyKAdminObject *_kadmin_init_with_ccache(PyObject *self, PyObject *args) 
                 db_args, 
                 &kadmin->server_handle);
 
-    if (retval != KADM5_OK) { 
-
-        Py_XDECREF(kadmin);
-        kadmin = NULL;
-
-        PyKAdminError_raise_error(retval, "kadm5_init_with_creds");
-    }
-
 
 cleanup:
     
@@ -327,6 +319,14 @@ cleanup:
 
     krb5_free_principal(kadmin->context, princ);
     krb5_cc_close(kadmin->context, cc);
+
+    if (retval != KADM5_OK) {
+
+        Py_XDECREF(kadmin);
+        kadmin = NULL;
+
+        PyKAdminError_raise_error(retval, "kadm5_init_with_creds");
+    }
 
     if (params)
         free(params);  


### PR DESCRIPTION
If kadm5_init_with_ccreds failed, the pointer to the kadmin Python object would
be set to NULL but cleanup would still try to use kadmin->context when freeing
princ and closing the ccache.