### PR TITLE
Fix #45: max (renewable) ticket life is negative

### DIFF
--- a/src/PyKAdminCommon.c
+++ b/src/PyKAdminCommon.c
@@ -62,7 +62,8 @@ char *pykadmin_timestamp_as_isodate(time_t timestamp, const char *zero) {
 char *pykadmin_timestamp_as_deltastr(int seconds, const char *zero) {
 
     char *deltastr = NULL;
-    int negative, days, hours, minutes; 
+    int days, hours, minutes;
+    int negative = 0;
 
     if (seconds != 0) {
 


### PR DESCRIPTION
Since the negative flag in the helper function pykadmin_timestamp_as_deltastr
was never initialized to zero, using it in a comparison reads random values off
the stack, which are more likely to be non-zero than zero. Hence, checking
whether the delta was negative would return true even in cases where the delta
was not negative.