### PR TITLE
remove inline qualifiers to avoid undefined symbol

### DIFF
--- a/src/PyKAdminCommon.c
+++ b/src/PyKAdminCommon.c
@@ -15,7 +15,7 @@ kadm5_get_principal(void *server_handle, krb5_principal principal,
 
 #define TIME_NONE ((time_t) -1)
 
-inline char *PyUnicode_or_PyBytes_asCString(PyObject *in_str) {
+char *PyUnicode_or_PyBytes_asCString(PyObject *in_str) {
 
     char *out_str = NULL;
 
@@ -95,7 +95,7 @@ char *pykadmin_timestamp_as_deltastr(int seconds, const char *zero) {
 
 
 
-inline PyObject *pykadmin_pydatetime_from_timestamp(time_t timestamp) {
+PyObject *pykadmin_pydatetime_from_timestamp(time_t timestamp) {
 
     PyDateTime_IMPORT;
 

--- a/src/PyKAdminCommon.h
+++ b/src/PyKAdminCommon.h
@@ -22,11 +22,11 @@
 #endif
 
 
-inline char *PyUnicode_or_PyBytes_asCString(PyObject *in_str);
+char *PyUnicode_or_PyBytes_asCString(PyObject *in_str);
 
 int pykadmin_policy_exists(void *server_handle, const char *name);
 
-inline PyObject *pykadmin_pydatetime_from_timestamp(time_t timestamp);
+PyObject *pykadmin_pydatetime_from_timestamp(time_t timestamp);
 int pykadmin_timestamp_from_pydatetime(PyObject *datetime);
 
 int pykadmin_seconds_from_pydatetime(PyObject *delta);


### PR DESCRIPTION
I am currently having a problem because of the inline qualifiers on the functions `pykadmin_pydatetime_from_timestamp` and `PyUnicode_or_PyBytes_asCString`. Indeed, they are inlined by the compiler, so the function is not created and can't be called from python.

This pull request only removes the inlining.

```
Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x7feb3e14dd90>
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/django/utils/autoreload.py", line 226, in wrapper
    fn(*args, **kwargs)
  File "/usr/lib/python3.5/site-packages/django/core/management/commands/runserver.py", line 109, in inner_run
    autoreload.raise_last_exception()
  File "/usr/lib/python3.5/site-packages/django/utils/autoreload.py", line 249, in raise_last_exception
    six.reraise(*_exception)
  File "/usr/lib/python3.5/site-packages/django/utils/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3.5/site-packages/django/utils/autoreload.py", line 226, in wrapper
    fn(*args, **kwargs)
  File "/usr/lib/python3.5/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/lib/python3.5/site-packages/django/apps/registry.py", line 115, in populate
    app_config.ready()
  File "/usr/lib/python3.5/site-packages/django/contrib/admin/apps.py", line 22, in ready
    self.module.autodiscover()
  File "/usr/lib/python3.5/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
    autodiscover_modules('admin', register_to=site)
  File "/usr/lib/python3.5/site-packages/django/utils/module_loading.py", line 50, in autodiscover_modules
    import_module('%s.%s' % (app_config.name, module_to_search))
  File "/usr/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/pluggi/cri/accounts-web/accounts_web/admin.py", line 7, in <module>
    from .user import krb_reset_password
  File "/home/pluggi/cri/accounts-web/accounts_web/user.py", line 1, in <module>
    import kadmin
ImportError: /usr/lib/python3.5/site-packages/kadmin.cpython-35m-x86_64-linux-gnu.so: undefined symbol: pykadmin_pydatetime_from_timestamp
```